### PR TITLE
Add a filter to disable the output cache

### DIFF
--- a/inc/classes/init.class.php
+++ b/inc/classes/init.class.php
@@ -345,7 +345,12 @@ class Init extends Query {
 
 		$cache_key = 'seo_framework_output_' . $key . '_' . $paged . '_' . $page;
 
-		$output = $this->object_cache_get( $cache_key );
+		if ( apply_filters( 'the_seo_framework_output_cache', true ) ) {
+			$output = $this->object_cache_get( $cache_key );
+		} else {
+			$output = false;
+		}
+		
 		if ( false === $output ) {
 
 			$robots = $this->robots();


### PR DESCRIPTION
A fix for #24 and doesn't hurt performance too much if an object cache is used.