### PR TITLE
Twitter Photo Card is deprecated

### DIFF
--- a/inc/classes/generate.class.php
+++ b/inc/classes/generate.class.php
@@ -415,8 +415,7 @@ class Generate extends Term_Data {
 	public function get_twitter_card_types() {
 		return array(
 			'summary'             => 'summary',
-			'summary_large_image' => 'summary-large-image',
-			'photo'               => 'photo',
+			'summary_large_image' => 'summary-large-image'
 		);
 	}
 }


### PR DESCRIPTION
Hi, the last option in the Twitter Card Types, actually doesn't work, since it was deprecated 'on July 3, 2015 and has been mapped to the Summary Card with Large Image.'

https://dev.twitter.com/cards/types/photo