### PR TITLE
Change date/time generation to use DATE_W3C format

### DIFF
--- a/inc/classes/render.class.php
+++ b/inc/classes/render.class.php
@@ -749,7 +749,7 @@ class Render extends Admin_Init {
 		 * @since 2.3.0
 		 * @since 2.7.0 Added output within filter.
 		 */
-		$time = (string) \apply_filters( 'the_seo_framework_publishedtime_output', \get_the_date( 'Y-m-d', $id ), $id );
+		$time = (string) \apply_filters( 'the_seo_framework_publishedtime_output', \get_the_date( DATE_W3C, $id ), $id );
 
 		if ( $time )
 			return '<meta property="article:published_time" content="' . \esc_attr( $time ) . '" />' . "\r\n";
@@ -797,7 +797,7 @@ class Render extends Admin_Init {
 		 * @since 2.3.0
 		 * @since 2.7.0 Added output within filter.
 		 */
-		$time = (string) \apply_filters( 'the_seo_framework_modifiedtime_output', \get_post_modified_time( 'Y-m-d', false, $id, false ), $id );
+		$time = (string) \apply_filters( 'the_seo_framework_modifiedtime_output', \get_post_modified_time( DATE_W3C, false, $id, false ), $id );
 
 		if ( $time ) {
 			$output = '<meta property="article:modified_time" content="' . \esc_attr( $time ) . '" />' . "\r\n";


### PR DESCRIPTION
The plugin is currently outputting the open graph article:published_time, article:modified_time and og:updated_time using only a Y-m-d format. This does not include any times, only the date.

We run a news site, and as important news breaks, it is common to have an article be modified one or more times during the day it was published. Rarely is the news article edited after the first day.

I have no idea how the Facebook scraper actually utilizes this tag, but it seems prudent to have a full date/time stamp for published and modified times so that their parser will know there has been an update.

This is a very simple change to use the PHP constant DATE_W3C.