### PR TITLE
Convert forgotten $unknown to a proper class name

### DIFF
--- a/inc/classes/doing-it-right.class.php
+++ b/inc/classes/doing-it-right.class.php
@@ -1719,7 +1719,7 @@ class Doing_It_Right extends Generate_Ldjson {
 
 		if ( ! $tit_len ) {
 			$notice = $i18n['length_empty'];
-			$class  = $unknown;
+			$class  = $classes['unknown'];
 		} elseif ( $tit_len < $guidelines['lower'] ) {
 			$notice = $i18n['length_far_too_short'];
 			$class  = $classes['bad'];


### PR DESCRIPTION
This prevents notices being generated in the post list view for posts with no title.