### PR TITLE
Fixes #381

### DIFF
--- a/inc/classes/generate-title.class.php
+++ b/inc/classes/generate-title.class.php
@@ -589,7 +589,7 @@ class Generate_Title extends Generate_Description {
 
 		$title = '';
 
-		if ( $args['taxonomy'] ) {
+		if ( isset( $args['taxonomy'] ) && $args['taxonomy'] ) {
 			$title = $this->get_generated_archive_title( \get_term( $args['id'], $args['taxonomy'] ) );
 		} else {
 			if ( $this->is_front_page_by_id( $args['id'] ) ) {


### PR DESCRIPTION
Issue where taxonomy index not defined when calling generate_title_from_args()

Checks if 'taxonomy' index exists before checking if it's value is truthy.