### PR TITLE
provide to the user the choice of enable/disable Primary Category feature.

### DIFF
--- a/autodescription.php
+++ b/autodescription.php
@@ -3,7 +3,7 @@
  * Plugin Name: The SEO Framework
  * Plugin URI: https://theseoframework.com/
  * Description: An automated, advanced, accessible, unbranded and extremely fast SEO solution for any WordPress website.
- * Version: 3.1.0-dev-2018.08.24.1
+ * Version: 3.2.0-dev-2018.08.25.0
  * Author: Sybre Waaijer
  * Author URI: https://theseoframework.com/
  * License: GPLv3
@@ -56,7 +56,7 @@ defined( 'ABSPATH' ) or die;
  *
  * @since 2.3.5
  */
-define( 'THE_SEO_FRAMEWORK_VERSION', '3.1.0' );
+define( 'THE_SEO_FRAMEWORK_VERSION', '3.2.0' );
 
 /**
  * The plugin Database version.

--- a/inc/classes/builders/og.class.php
+++ b/inc/classes/builders/og.class.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * @package The_SEO_Framework\Classes\Builders
+ * @subpackage The_SEO_Framework\Builders
+ */
+namespace The_SEO_Framework\Builders;
+
+defined( 'THE_SEO_FRAMEWORK_PRESENT' ) or die;
+
+/**
+ * The SEO Framework plugin
+ * Copyright (C) 2018 Sybre Waaijer, CyberWire (https://cyberwire.nl/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+\The_SEO_Framework\_load_trait( 'generator/meta' );
+
+/**
+ * Builds Open Graph metadata.
+ *
+ * @since 3.1.0
+ * @see the_seo_framework()->OG()
+ * @access private
+ *         Use `the_seo_framework()->OG()` instead.
+ * @final Can't be extended.
+ */
+final class OG {
+	use \The_SEO_Framework\Meta_Generator;
+
+	public function __construct() {
+		$this->init();
+	}
+
+	public function build() {
+
+		if ( ! $this->tsf->get_option( 'og_tags' ) ) {
+			$this->set_failure( 'DISABLED_VIA_OPTIONS' );
+			return false;
+		}
+
+		$this->can_fail = true;
+
+		if ( ! $this->parse_simple( [
+			'title'       => 'get_title',
+			'description' => 'get_description',
+			'url'         => 'get_url',
+		] ) )
+			return false;
+
+		if ( ! $this->parse_complex( [
+			'image' => 'get_image',
+		] ) )
+			return false;
+
+		$this->can_fail = false;
+
+		$this->parse_simple( [
+			'locale'   => 'get_locale',
+			'type'     => 'get_type',
+			'sitename' => 'get_sitename',
+		] );
+
+		return true;
+	}
+
+	public function get_title() {
+		/**
+		 * @since 2.3.0
+		 * @since 2.7.0 Added output within filter.
+		 * @param string $title The generated Open Graph title.
+		 * @param int    $id    The page or term ID.
+		 */
+		$title = (string) \apply_filters_ref_array(
+			'the_seo_framework_ogtitle_output',
+			[
+				$this->tsf->get_open_graph_title(),
+				$this->id,
+			]
+		);
+
+		if ( $title ) {
+			return [
+				'@tag'     => 'meta',
+				'property' => 'og:title',
+				'content'  => $title,
+			];
+		} else {
+			$this->set_failure( 'NO_TITLE' );
+			return [];
+		}
+	}
+
+	public function get_description() {
+		/**
+		 * @since 2.3.0
+		 * @since 2.7.0 Added output within filter.
+		 * @param string $description The generated Open Graph description.
+		 * @param int    $id          The page or term ID.
+		 */
+		$description = (string) \apply_filters_ref_array(
+			'the_seo_framework_ogdescription_output',
+			[
+				$this->tsf->get_open_graph_description(),
+				$this->id,
+			]
+		);
+
+		if ( $description ) {
+			return [
+				'@tag'     => 'meta',
+				'property' => 'og:description',
+				'content'  => $description,
+			];
+		} else {
+			$this->set_failure( 'NO_DESCRIPTION' );
+			return [];
+		}
+	}
+
+	public function get_url() {
+		/**
+		 * @since 2.9.3
+		 * @param string $url The canonical/Open Graph URL. Must be escaped.
+		 * @param int    $id  The current page or term ID.
+		 */
+		$url = (string) \apply_filters_ref_array(
+			'the_seo_framework_ogurl_output',
+			[
+				$this->tsf->get_current_canonical_url(),
+				$this->id,
+			]
+		);
+
+		if ( $url ) {
+			return [
+				'@tag'     => 'meta',
+				'property' => 'og:url',
+				'content'  => $url,
+			];
+		} else {
+			$this->set_failure( 'NO_URL' );
+			return [];
+		}
+	}
+
+	public function get_image() {
+		/**
+		 * @NOTE: Use of this might cause incorrect meta since other functions
+		 * depend on the image from cache.
+		 * @since 2.3.0
+		 * @since 2.7.0 Added output within filter.
+		 * @since 3.1.0 Now accepts an array of images
+		 * @param string|array $image The social image URL.
+		 * @param int          $id    The page or term ID.
+		 */
+		$images = (array) \apply_filters_ref_array(
+			'the_seo_framework_ogimage_output',
+			[
+				$this->tsf->get_image_from_cache(),
+				$this->id,
+			]
+		);
+
+		if ( $images ) {
+			$ret = [];
+			$i = 0;
+			foreach ( $images as $image ) {
+				$ret[ $i ]['image'] = [
+					'@tag'     => 'meta',
+					'property' => 'og:image',
+					'content'  => $image,
+				];
+
+				if ( ! empty( $this->tsf->image_dimensions[ $this->id ]['width'] )
+				&& ! empty( $this->tsf->image_dimensions[ $this->id ]['height'] ) ) {
+					$ret[ $i ]['width'] = [
+						'@tag'     => 'meta',
+						'property' => 'og:image:width',
+						'content'  => $this->tsf->image_dimensions[ $this->id ]['width'],
+					];
+					$ret[ $i ]['height'] = [
+						'@tag'     => 'meta',
+						'property' => 'og:image:height',
+						'content'  => $this->tsf->image_dimensions[ $this->id ]['height'],
+					];
+				}
+				$i++;
+			}
+			return $ret;
+		} else {
+			$this->set_failure( 'NO_IMAGE' );
+			return [];
+		}
+	}
+
+	public function get_locale() {
+		/**
+		 * @since 2.3.0
+		 * @since 2.7.0 Added output within filter.
+		 * @param string $locale The generated locale field.
+		 * @param int    $id     The page or term ID.
+		 */
+		$locale = (string) \apply_filters_ref_array(
+			'the_seo_framework_oglocale_output',
+			[
+				$this->tsf->fetch_locale(),
+				$this->id,
+			]
+		);
+
+		if ( $locale ) {
+			return [
+				'@tag'     => 'meta',
+				'property' => 'og:locale',
+				'content'  => $locale,
+			];
+		}
+
+		return [];
+	}
+
+	public function get_type() {
+
+		$type = $this->tsf->get_og_type();
+
+		if ( $type ) {
+			return [
+				'@tag'     => 'meta',
+				'property' => 'og:type',
+				'content'  => $type,
+			];
+		}
+
+		return [];
+	}
+
+	public function get_sitename() {
+		/**
+		 * @since 2.3.0
+		 * @since 2.7.0 Added output within filter.
+		 * @param string $sitename The generated Open Graph site name.
+		 * @param int    $id       The page or term ID.
+		 */
+		$sitename = (string) \apply_filters_ref_array(
+			'the_seo_framework_ogsitename_output',
+			[
+				$this->tsf->get_blogname(),
+				$this->id,
+			]
+		);
+
+		if ( $sitename ) {
+			return [
+				'@tag'     => 'meta',
+				'property' => 'og:site_name',
+				'content'  => $sitename,
+			];
+		}
+
+		return [];
+	}
+}

--- a/inc/classes/builders/scripts.class.php
+++ b/inc/classes/builders/scripts.class.php
@@ -148,7 +148,7 @@ final class Scripts {
 	 * @see $this->enqueue_scripts()
 	 *
 	 * @NOTE If the script is associative, it'll be registered as-is.
-	 *       If the script is sequential (weak check!!!), it'll be iterated over, and then registered.
+	 *       If the script is sequential, it'll be iterated over, and then registered.
 	 *
 	 * @param array $script The script : {
 	 *   'id'   => string The script ID,
@@ -172,7 +172,7 @@ final class Scripts {
 	 * }
 	 */
 	public static function register( array $script ) {
-		if ( isset( $script[0] ) ) {
+		if ( array_values( $script ) === $script ) {
 			foreach ( $script as $s ) static::register( $s );
 			return;
 		}

--- a/inc/classes/builders/twitter.class.php
+++ b/inc/classes/builders/twitter.class.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package The_SEO_Framework\Classes\Builders
+ * @subpackage The_SEO_Framework\Builders
+ */
+namespace The_SEO_Framework\Builders;
+
+/**
+ * The SEO Framework plugin
+ * Copyright (C) 2018 Sybre Waaijer, CyberWire (https://cyberwire.nl/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+defined( 'THE_SEO_FRAMEWORK_PRESENT' ) or die;
+
+// TODO...
+
+final class Twitter { }

--- a/inc/classes/init.class.php
+++ b/inc/classes/init.class.php
@@ -418,57 +418,27 @@ class Init extends Query {
 
 			//* Limit processing and redundant tags on 404 and search.
 			if ( $this->is_search() ) :
-				$output = $this->og_locale()
-						. $this->og_type()
-						. $this->og_title()
-						. $this->og_url()
-						. $this->og_sitename()
-						. $this->shortlink()
-						. $this->canonical()
-						. $this->paged_urls()
-						. $this->google_site_output()
-						. $this->bing_site_output()
-						. $this->yandex_site_output()
-						. $this->pint_site_output();
+				$output = $this->get_all_facebook_meta_tags()
+						. $this->get_all_canonical_meta_tags();
 			elseif ( $this->is_404() ) :
-				$output = $this->google_site_output()
-						. $this->bing_site_output()
-						. $this->yandex_site_output()
-						. $this->pint_site_output();
+				// Inferred.
 			else :
 				$set_timezone = $this->uses_time_in_timestamp_format() && ( $this->output_published_time() || $this->output_modified_time() );
 				$set_timezone and $this->set_timezone();
 
 				$output = $this->the_description()
-						. $this->og_image()
-						. $this->og_locale()
-						. $this->og_type()
-						. $this->og_title()
-						. $this->og_description()
-						. $this->og_url()
-						. $this->og_sitename()
-						. $this->facebook_publisher()
-						. $this->facebook_author()
-						. $this->facebook_app_id()
+						. $this->get_all_og_meta_tags()
+						. $this->get_all_facebook_meta_tags()
 						. $this->article_published_time()
 						. $this->article_modified_time()
-						. $this->twitter_card()
-						. $this->twitter_site()
-						. $this->twitter_creator()
-						. $this->twitter_title()
-						. $this->twitter_description()
-						. $this->twitter_image()
-						. $this->shortlink()
-						. $this->canonical()
-						. $this->paged_urls()
-						. $this->ld_json()
-						. $this->google_site_output()
-						. $this->bing_site_output()
-						. $this->yandex_site_output()
-						. $this->pint_site_output();
+						. $this->get_all_twitter_meta_tags()
+						. $this->get_all_canonical_meta_tags()
+						. $this->get_all_structured_data_scripts();
 
 				$set_timezone and $this->reset_timezone();
 			endif;
+
+			$output .= $this->get_all_verification_meta_tags();
 
 			$after_legacy = $this->get_legacy_header_filters_output( 'after' );
 

--- a/inc/classes/query.class.php
+++ b/inc/classes/query.class.php
@@ -265,18 +265,25 @@ class Query extends Compat {
 	 * Returns the current taxonomy, if any.
 	 *
 	 * @since 3.0.0
-	 * @since 3.1.0 Now works in the admin.
+	 * @since 3.1.0 1. Now works in the admin.
+	 *              2. Added caching
 	 * @global \WP_Screen $current_screen
+	 * @staticvar string $cache
 	 *
 	 * @return string The queried taxonomy type.
 	 */
 	public function get_current_taxonomy() {
+
+		static $cache;
+
+		if ( isset( $cache ) ) return $cache;
+
 		if ( $this->is_admin() ) {
 			global $current_screen;
-			return ! empty( $current_screen->taxonomy ) ? $current_screen->taxonomy : '';
+			return $cache = ! empty( $current_screen->taxonomy ) ? $current_screen->taxonomy : '';
 		} else {
 			$_object = \get_queried_object();
-			return ! empty( $_object->taxonomy ) ? $_object->taxonomy : '';
+			return $cache = ! empty( $_object->taxonomy ) ? $_object->taxonomy : '';
 		}
 	}
 

--- a/inc/traits/generator/meta.trait.php
+++ b/inc/traits/generator/meta.trait.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * @package The_SEO_Framework\Traits
+ */
+namespace The_SEO_Framework;
+
+defined( 'THE_SEO_FRAMEWORK_PRESENT' ) or die;
+
+/**
+ * The SEO Framework plugin
+ * Copyright (C) 2018 Sybre Waaijer, CyberWire (https://cyberwire.nl/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+trait Meta_Generator {
+
+	private $data     = [];
+	private $metatags = [];
+	private $failure  = '';
+
+	/** @var bool $can_fail Set to true to halt all class output on failure. */
+	protected $can_fail = false;
+
+	protected $tsf;
+	protected $id;
+	protected $taxonomy;
+
+	abstract public function build();
+
+	final public function __get( $key ) {
+		return $this->$key;
+	}
+
+	final public function __toString() {
+		$string = implode( PHP_EOL, $this->_normalize_tags() );
+		return $string ? $string . PHP_EOL : '';
+	}
+
+	/**
+	 * Initializes class vars.
+	 *
+	 * This is needed because we can't generate a predefined __construct() via a
+	 * trait prior PHP 5.5.21 or 5.6.5
+	 */
+	final protected function init() {
+		$this->tsf      = \the_seo_framework();
+		$this->id       = $this->tsf->get_the_real_ID() ?: 0;
+		$this->taxonomy = $this->tsf->get_current_taxonomy() ?: '';
+	}
+
+
+	final public function &_collect_data() {
+		return $this->data;
+	}
+
+	final public function create_metatags() {
+		$tags = &$this->_collect_tags();
+		foreach ( $this->_read_data() as $type => $data ) {
+			$tags[ $type ] = $this->_create_metatags_deep( $data );
+		}
+	}
+
+	final private function _create_metatags_deep( array $data ) {
+
+		$tags = [];
+
+		if ( isset( $data['@complex'] ) ) {
+			unset( $data['@complex'] );
+			foreach ( $data as $it ) {
+				if ( isset( $it['@complex'] ) ) {
+					$tags[] = $this->_create_metatags_deep( $it );
+				} else {
+					$tags[] = $this->make_tag( $it );
+				}
+			}
+		} else {
+			$tags = $this->make_tag( $data );
+		}
+
+		return $tags;
+	}
+
+	final public function _read_data() {
+		return $this->data;
+	}
+
+	final protected function set_failure( $reason ) {
+		$this->failure = $reason;
+	}
+
+	final protected function parse_simple( array $meta ) {
+
+		$_data = &$this->_collect_data();
+
+		foreach ( $meta as $key => $cb ) {
+			if ( $val = $this->{$cb}() ) {
+				$_data[ $key ] = $val;
+			} elseif ( $this->can_fail ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	final protected function parse_complex( array $meta ) {
+
+		$_data = &$this->_collect_data();
+
+		foreach ( $meta as $key => $cb ) {
+			if ( $_val = $this->{$cb}() ) {
+				if ( $_val = $this->_parse_complex_deep( '@', $_val )['@'] ) {
+					$_data[ $key ] = $_val;
+				} elseif ( $this->can_fail ) {
+					return false;
+				}
+			} elseif ( $this->can_fail ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	final protected function _parse_complex_deep( $key, array $val ) {
+
+		// Test if deeper: Associative.
+		if ( array_values( $val ) === $val ) {
+			$data = [];
+			foreach ( $val as $sub => $val ) {
+				$data[ $key ][ $sub ] = $this->_parse_complex_deep( '@', $val )['@'];
+				$data[ $key ][ $sub ]['@complex'] = true;
+			}
+			$data[ $key ]['@complex'] = true;
+			return $data;
+		}
+
+		foreach ( $val as $k => $v ) {
+			if ( $v ) {
+				$data[ $key ][ $k ] = $v;
+			} elseif ( $this->can_fail ) {
+				return false;
+			}
+		}
+		$data[ $key ]['@complex'] = true;
+		return $data;
+	}
+
+	final private function &_collect_tags() {
+		return $this->metatags;
+	}
+
+	/* Generator syntax please... I want PHP 5.5+ :( */
+	final private function _normalize_tags() {
+
+		$tags = [];
+
+		foreach ( $this->metatags as $tag ) {
+			if ( is_array( $tag ) ) {
+				foreach ( array_reduce( $tag, 'array_merge', [] ) as $_tag ) {
+					$tags[] = $_tag;
+				}
+			} else {
+				$tags[] = $tag;
+			}
+		}
+
+		return $tags;
+	}
+
+	final private function make_tag( array $data ) {
+
+		$tag = $data['@tag'];
+		unset( $data['@tag'] );
+
+		$content = '';
+		foreach ( $data as $a => $b )
+			$content .= sprintf( '%s="%s" ', $a, \esc_attr( $b ) );
+
+		return sprintf( '<%s %s />', $tag, trim( $content ) );
+	}
+}


### PR DESCRIPTION
Hello,
I hope it is the right place to pull a request/feature for the following SEO framework plugin.
This pull request is related to the following post:
https://wordpress.org/support/topic/disable-primary-category/
As previously said on wordpress support forum:

I recently discovered that when creating new products and choosing some category.
your plugin features: ‘primary category’ is always choosing the parent category as default. For example:

if my product is a shoe and my category is:
Shoes->For Men->city->leather
your plugin will choose as default if nothing is ticked:
Shoes
and woocommerce would display
Shoes->For Men->city->leather
if your plugin is deactivated. which is way more efficient for me. Therefore customer has access to a wider choice in the breadcrumb and can also in one click view and compare all the leather shoes.


So I would personally be very interested into having the choice to deactivate this functionality. I do spent time to write this comment, because I do love the SEO Framework plugin. I wish for nothing to switch to any other heavy SEO plugin for my website.

Thanks in advance to consider this request.

Jé
