### PR TITLE
Fix non-existent method in Cache

### DIFF
--- a/inc/classes/bridges/cache.class.php
+++ b/inc/classes/bridges/cache.class.php
@@ -142,7 +142,7 @@ final class Cache {
 			   ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) )
 			&& \check_admin_referer( 'update-permalink' )
 		) {
-				return static::refresh_sitemaps();
+				return Sitemap::refresh_sitemaps();
 		}
 
 		return false;


### PR DESCRIPTION
I'm not able to proceed.

Control structures are missing braces.
```php
if (condition) return;
// Should be
if (condition) {
    return;
}
```

Assignment in another statement.
```php
return $memo = false;
// Should be
$memo = false;

return $memo;
```

181 TODOs, FIXMEs.

33 pass-by-ref variables, methods.

How to clear these 🚧 road blocks?
