### PR TITLE
Use braces in control structures

### DIFF
--- a/bootstrap/activation.php
+++ b/bootstrap/activation.php
@@ -26,7 +26,9 @@ namespace The_SEO_Framework\Bootstrap;
 
 $tsf = \tsf();
 
-if ( ! $tsf->loaded ) return;
+if ( ! $tsf->loaded ) {
+	return;
+}
 
 $tsf->reset_check_plugin_conflicts();
 
@@ -41,10 +43,12 @@ turn_on_autoloading: {
 
 	$temp_options = $options;
 	// Write a small difference, so the change will be forwarded to the database.
-	if ( \is_array( $temp_options ) )
+	if ( \is_array( $temp_options ) ) {
 		$temp_options['update_buster'] = (int) time();
+	}
 
 	$_success = \update_option( $setting, $temp_options, 'yes' );
-	if ( $_success )
+	if ( $_success ) {
 		\update_option( $setting, $options, 'yes' );
+	}
 }

--- a/bootstrap/deactivation.php
+++ b/bootstrap/deactivation.php
@@ -26,7 +26,9 @@ namespace The_SEO_Framework\Bootstrap;
 
 $tsf = \tsf();
 
-if ( ! $tsf->loaded ) return;
+if ( ! $tsf->loaded ) {
+	return;
+}
 
 turn_off_autoloading: {
 	$options = $tsf->get_all_options();
@@ -38,10 +40,12 @@ turn_off_autoloading: {
 
 	$temp_options = $options;
 	// Write a small difference, so the change will be forwarded to the database.
-	if ( \is_array( $temp_options ) )
+	if ( \is_array( $temp_options ) ) {
 		$temp_options['update_buster'] = (int) time();
+	}
 
 	$_success = \update_option( $setting, $temp_options, 'no' );
-	if ( $_success )
+	if ( $_success ) {
 		\update_option( $setting, $options, 'no' );
+	}
 }

--- a/bootstrap/load.php
+++ b/bootstrap/load.php
@@ -63,8 +63,9 @@ function _init_tsf() {
 	// Memoize the class. Do not run constructors more than once.
 	static $tsf = null;
 
-	if ( $tsf )
+	if ( $tsf ) {
 		return $tsf;
+	}
 
 	/**
 	 * @since 2.3.7
@@ -96,8 +97,9 @@ function _init_tsf() {
 	}
 
 	// did_action() checks for current action too.
-	if ( ! \did_action( 'plugins_loaded' ) )
+	if ( ! \did_action( 'plugins_loaded' ) ) {
 		$tsf->_doing_it_wrong( 'tsf(), the_seo_framework(), or ' . __FUNCTION__, 'Use <code>tsf()</code> after action <code>plugins_loaded</code> priority 5.', '3.1' );
+	}
 
 	return $tsf;
 }
@@ -128,7 +130,9 @@ function _autoload_classes( $class ) {
 	$class = strtolower( $class );
 
 	// It's The_SEO_Framework, not the_seo_framework! -- Sybre's a nightmare, honestly! No wonder he hasn't gotten any friends.
-	if ( 0 !== strpos( $class, 'the_seo_framework\\', 0 ) ) return;
+	if ( 0 !== strpos( $class, 'the_seo_framework\\', 0 ) ) {
+		return;
+	}
 
 	static $_timenow = true;
 	// Lock $_timenow to prevent stacking timers during class extending. This is released when the class stack loaded.

--- a/bootstrap/upgrade.php
+++ b/bootstrap/upgrade.php
@@ -104,7 +104,9 @@ function _do_upgrade() {
 
 	$tsf = \tsf();
 
-	if ( ! $tsf->loaded || \wp_doing_ajax() ) return;
+	if ( ! $tsf->loaded || \wp_doing_ajax() ) {
+		return;
+	}
 
 	if ( $tsf->is_seo_settings_page( false ) ) {
 		// phpcs:ignore, WordPress.Security.SafeRedirect -- self_admin_url() is safe.
@@ -116,7 +118,9 @@ function _do_upgrade() {
 
 	$lock = _set_upgrade_lock( $timeout );
 	// Lock failed to create--probably because it was already locked (or the database failed us).
-	if ( ! $lock ) return;
+	if ( ! $lock ) {
+		return;
+	}
 
 	// Register this AFTER the lock is set. Otherwise, it may clear the lock in another thread.
 	// This releases the lock when the upgrade crashes or when we forget to unlock it...
@@ -126,8 +130,9 @@ function _do_upgrade() {
 	\wp_raise_memory_limit( 'tsf_upgrade' );
 
 	$ini_max_execution_time = (int) ini_get( 'max_execution_time' );
-	if ( 0 !== $ini_max_execution_time )
+	if ( 0 !== $ini_max_execution_time ) {
 		set_time_limit( max( $ini_max_execution_time, $timeout ) );
+	}
 
 	/**
 	 * Clear the cache to prevent an update_option() from saving a stale database version to the cache.
@@ -261,12 +266,14 @@ function _set_upgrade_lock( $release_timeout ) {
 		$lock_result = \get_option( $lock_option );
 
 		// If a lock couldn't be created, and there isn't a lock, bail.
-		if ( ! $lock_result )
+		if ( ! $lock_result ) {
 			return false;
+		}
 
 		// Check to see if the lock is still valid. If it is, bail.
-		if ( $lock_result > ( time() - $release_timeout ) )
+		if ( $lock_result > ( time() - $release_timeout ) ) {
 			return false;
+		}
 
 		// There must exist an expired lock, clear it...
 		_release_upgrade_lock();
@@ -488,8 +495,9 @@ function _prepare_upgrade_notice( $previous_version, $current_version ) {
 		];
 
 		$esc_sql_in = function( $var ) {
-			if ( ! is_scalar( $var ) )
+			if ( ! is_scalar( $var ) ) {
 				$var = array_filter( (array) $var, 'is_scalar' );
+			}
 			return \esc_sql( $var );
 		};
 
@@ -557,10 +565,14 @@ function _prepare_upgrade_notice( $previous_version, $current_version ) {
  */
 function _prepare_upgrade_suggestion( $previous_version, $current_version ) { // phpcs:ignore, VariableAnalysis.CodeAnalysis.VariableAnalysis
 	// Don't invoke if the user didn't upgrade.
-	if ( ! $previous_version ) return;
+	if ( ! $previous_version ) {
+		return;
+	}
 
 	// Can this even run twice? Let's play it safe to prevent crashes.
-	if ( \The_SEO_Framework\has_run( __METHOD__ ) ) return;
+	if ( \The_SEO_Framework\has_run( __METHOD__ ) ) {
+		return;
+	}
 
 	require \THE_SEO_FRAMEWORK_DIR_PATH_FUNCT . 'upgrade-suggestion.php';
 }
@@ -614,8 +626,9 @@ function _do_upgrade_2701() {
 
 	if ( $term_meta ) {
 
-		foreach ( (array) $term_meta as $term_id => $meta )
+		foreach ( (array) $term_meta as $term_id => $meta ) {
 			\add_term_meta( $term_id, \THE_SEO_FRAMEWORK_TERM_OPTIONS, $meta, true );
+		}
 
 		// Rudimentary test for remaining ~300 users of earlier versions passed, set initial version to 2600.
 		\update_option( 'the_seo_framework_initial_db_version', '2600', 'no' );
@@ -629,8 +642,9 @@ function _do_upgrade_2701() {
  */
 function _do_upgrade_2802() {
 	// Delete old values from database. Removes backwards compatibility.
-	if ( \get_option( 'the_seo_framework_initial_db_version' ) < '2701' )
+	if ( \get_option( 'the_seo_framework_initial_db_version' ) < '2701' ) {
 		\delete_option( 'autodescription-term-meta' );
+	}
 }
 
 /**
@@ -719,8 +733,9 @@ function _do_upgrade_3103() {
 			$_value = [];
 
 			// Only populate when set. An empty array is fine.
-			if ( $_attachment_option )
+			if ( $_attachment_option ) {
 				$_value['attachment'] = $_attachment_option;
+			}
 
 			$tsf->update_option( $tsf->get_robots_post_type_option_id( $r ), $_value );
 		}
@@ -761,8 +776,9 @@ function _do_upgrade_3300() {
 		\add_action( 'shutdown', 'flush_rewrite_rules' );
 
 		// Convert 'dash' title option to 'hyphen', silently. Nothing notably changes for the user.
-		if ( 'dash' === $tsf->get_option( 'title_separator', false ) )
+		if ( 'dash' === $tsf->get_option( 'title_separator', false ) ) {
 			$tsf->update_option( 'title_separator', 'hyphen' );
+		}
 
 		// Add default cron pinging option.
 		$tsf->update_option( 'ping_use_cron', 1 );
@@ -844,10 +860,12 @@ function _do_upgrade_4103() {
 			$_category_option = (int) (bool) $tsf->get_option( "category_$r", false );
 			$_post_tag_option = (int) (bool) $tsf->get_option( "tag_$r", false );
 
-			if ( $_category_option )
+			if ( $_category_option ) {
 				$_value['category'] = $_category_option;
-			if ( $_post_tag_option )
+			}
+			if ( $_post_tag_option ) {
 				$_value['post_tag'] = $_post_tag_option;
+			}
 
 			$tsf->update_option( $tsf->get_robots_taxonomy_option_id( $r ), $_value );
 		}

--- a/inc/classes/admin-init.class.php
+++ b/inc/classes/admin-init.class.php
@@ -42,8 +42,9 @@ class Admin_Init extends Init {
 	 * @access private
 	 */
 	public function _init_seo_bar_tables() {
-		if ( $this->get_option( 'display_seo_bar_tables' ) )
+		if ( $this->get_option( 'display_seo_bar_tables' ) ) {
 			new Bridges\SEOBar;
+		}
 	}
 
 	/**
@@ -74,11 +75,13 @@ class Admin_Init extends Init {
 			$search_exclude  = $this->get_option( 'alter_search_query' ) && $this->get_post_meta_item( 'exclude_local_search', $post_id );
 			$archive_exclude = $this->get_option( 'alter_archive_query' ) && $this->get_post_meta_item( 'exclude_from_archive', $post_id );
 
-			if ( $search_exclude )
+			if ( $search_exclude ) {
 				$states[] = \esc_html__( 'No Search', 'autodescription' );
+			}
 
-			if ( $archive_exclude )
+			if ( $archive_exclude ) {
 				$states[] = \esc_html__( 'No Archive', 'autodescription' );
+			}
 		}
 
 		return $states;
@@ -122,7 +125,9 @@ class Admin_Init extends Init {
 	 */
 	public function init_admin_scripts() {
 
-		if ( has_run( __METHOD__ ) ) return;
+		if ( has_run( __METHOD__ ) ) {
+			return;
+		}
 
 		Bridges\Scripts::_init();
 	}
@@ -158,7 +163,9 @@ class Admin_Init extends Init {
 		$locale = substr( $locale, 0, 5 );
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo( null, $locale ) ) return $memo;
+		if ( null !== $memo = memo( null, $locale ) ) {
+			return $memo;
+		}
 
 		// phpcs:disable, WordPress.WhiteSpace.OperatorSpacing.SpacingAfter
 		$character_adjustments = [
@@ -361,7 +368,9 @@ class Admin_Init extends Init {
 	 */
 	public function admin_redirect( $page, $query_args = [] ) {
 
-		if ( empty( $page ) ) return;
+		if ( empty( $page ) ) {
+			return;
+		}
 
 		// This can be empty... so $target will be empty. TODO test for $success and bail?
 		// Might cause security issues... we _must_ exit, always? Show warning?
@@ -381,7 +390,9 @@ class Admin_Init extends Init {
 			$location     = sprintf( 'Location: %s', \wp_sanitize_redirect( $target ) );
 
 			// Test if WordPress's redirect header is sent. Bail if true.
-			if ( \in_array( $location, $headers_list, true ) ) exit;
+			if ( \in_array( $location, $headers_list, true ) ) {
+				exit;
+			}
 
 			// phpcs:disable, WordPress.Security.EscapeOutput -- convert_markdown escapes. Added esc_url() for sanity.
 			printf(
@@ -434,7 +445,9 @@ class Admin_Init extends Init {
 
 		// We made this mistake ourselves. Let's test against it.
 		// We can't type $key to scalar, for PHP is dumb with that type.
-		if ( ! is_scalar( $key ) || ! \strlen( $key ) ) return;
+		if ( ! is_scalar( $key ) || ! \strlen( $key ) ) {
+			return;
+		}
 
 		// Sanitize the key so that HTML, JS, and PHP can communicate easily via it.
 		$key = \sanitize_key( $key );
@@ -461,14 +474,19 @@ class Admin_Init extends Init {
 		);
 
 		// Required key for security.
-		if ( ! $conditions['capability'] ) return;
+		if ( ! $conditions['capability'] ) {
+			return;
+		}
 
 		// Timeout already expired. Let's not register it.
-		if ( $conditions['timeout'] < -1 ) return;
+		if ( $conditions['timeout'] < -1 ) {
+			return;
+		}
 
 		// Add current time to timeout, so we can compare against it later.
-		if ( $conditions['timeout'] > -1 )
+		if ( $conditions['timeout'] > -1 ) {
 			$conditions['timeout'] += time();
+		}
 
 		$notices         = $this->get_static_cache( 'persistent_notices', [] );
 		$notices[ $key ] = compact( 'message', 'args', 'conditions' );
@@ -490,8 +508,9 @@ class Admin_Init extends Init {
 
 		$_count_before = $count;
 
-		if ( $count > 0 )
+		if ( $count > 0 ) {
 			--$count;
+		}
 
 		if ( ! $count ) {
 			$this->clear_persistent_notice( $key );
@@ -560,11 +579,15 @@ class Admin_Init extends Init {
 		// phpcs:ignore, WordPress.Security.NonceVerification.Missing -- We require the POST data to find locally stored nonces.
 		$key = \sanitize_key( $_POST['tsf-notice-submit'] ?? '' );
 
-		if ( ! $key ) return;
+		if ( ! $key ) {
+			return;
+		}
 
 		$notices = $this->get_static_cache( 'persistent_notices', [] );
 		// Notice was deleted already elsewhere, or key was faulty. Either way, ignore--should be self-resolving.
-		if ( empty( $notices[ $key ]['conditions']['capability'] ) ) return;
+		if ( empty( $notices[ $key ]['conditions']['capability'] ) ) {
+			return;
+		}
 
 		if (
 			   ! \current_user_can( $notices[ $key ]['conditions']['capability'] )

--- a/inc/classes/admin-pages.class.php
+++ b/inc/classes/admin-pages.class.php
@@ -50,12 +50,15 @@ class Admin_Pages extends Generate_Ldjson {
 	 */
 	public function add_menu_link() {
 
-		if ( has_run( __METHOD__ ) ) return;
+		if ( has_run( __METHOD__ ) ) {
+			return;
+		}
 
 		$issue_count = $this->get_admin_issue_count();
 
-		if ( $issue_count )
+		if ( $issue_count ) {
 			$issue_badge = $this->get_admin_menu_issue_badge( $issue_count );
+		}
 
 		/**
 		 * @since 4.2.8
@@ -112,7 +115,9 @@ class Admin_Pages extends Generate_Ldjson {
 	 */
 	public function get_admin_issue_count() {
 
-		if ( $this->is_headless['settings'] ) return 0;
+		if ( $this->is_headless['settings'] ) {
+			return 0;
+		}
 
 		/**
 		 * @since 4.2.8
@@ -182,7 +187,9 @@ class Admin_Pages extends Generate_Ldjson {
 	 */
 	public function _init_post_edit_view( $post_type, $post ) {
 
-		if ( ! $this->is_post_edit() || ! $this->is_post_type_supported( $post_type ) ) return;
+		if ( ! $this->is_post_edit() || ! $this->is_post_type_supported( $post_type ) ) {
+			return;
+		}
 
 		/**
 		 * @since 2.0.0
@@ -190,11 +197,12 @@ class Admin_Pages extends Generate_Ldjson {
 		 */
 		$show_seobox = (bool) \apply_filters( 'the_seo_framework_seobox_output', true );
 
-		if ( $show_seobox )
+		if ( $show_seobox ) {
 			\add_action(
 				'add_meta_boxes',
 				[ Bridges\PostSettings::class, '_prepare_meta_box' ]
 			);
+		}
 	}
 
 	/**
@@ -204,11 +212,15 @@ class Admin_Pages extends Generate_Ldjson {
 	 */
 	public function _init_term_edit_view() {
 
-		if ( ! $this->is_term_edit() ) return;
+		if ( ! $this->is_term_edit() ) {
+			return;
+		}
 
 		$taxonomy = $this->get_current_taxonomy();
 
-		if ( ! $this->is_taxonomy_supported( $taxonomy ) ) return;
+		if ( ! $this->is_taxonomy_supported( $taxonomy ) ) {
+			return;
+		}
 
 		/**
 		 * @since 2.6.0
@@ -233,7 +245,9 @@ class Admin_Pages extends Generate_Ldjson {
 	 */
 	public function _init_user_edit_view() {
 
-		if ( ! $this->is_profile_edit() ) return;
+		if ( ! $this->is_profile_edit() ) {
+			return;
+		}
 
 		// WordPress made a mess of this. We can't reliably get a user future-proof. Load class for all users; check there.
 		// if ( ! $user->has_cap( \THE_SEO_FRAMEWORK_AUTHOR_INFO_CAP ) ) return;
@@ -253,7 +267,9 @@ class Admin_Pages extends Generate_Ldjson {
 
 		$notice = $this->get_static_cache( 'settings_notice' );
 
-		if ( ! $notice ) return;
+		if ( ! $notice ) {
+			return;
+		}
 
 		$message = '';
 		$type    = '';
@@ -425,7 +441,9 @@ class Admin_Pages extends Generate_Ldjson {
 				|| ( $cond['user'] && $cond['user'] !== $this->get_user_id() )
 				|| ( $cond['screens'] && ! \in_array( $screenbase, $cond['screens'], true ) )
 				|| ( $cond['excl_screens'] && \in_array( $screenbase, $cond['excl_screens'], true ) )
-			) continue;
+			) {
+				continue;
+			}
 
 			if ( -1 !== $cond['timeout'] && $cond['timeout'] < time() ) {
 				$this->clear_persistent_notice( $key );

--- a/inc/classes/bridges/cache.class.php
+++ b/inc/classes/bridges/cache.class.php
@@ -117,13 +117,16 @@ final class Cache {
 	 */
 	public static function _refresh_sitemap_on_post_change( $post_id ) {
 
-		if ( ! $post_id ) return false;
+		if ( ! $post_id ) {
+			return false;
+		}
 
 		$success = false;
 
 		// Don't refresh sitemap on revision.
-		if ( ! \wp_is_post_revision( $post_id ) )
+		if ( ! \wp_is_post_revision( $post_id ) ) {
 			$success = Sitemap::refresh_sitemaps();
+		}
 
 		return $success;
 	}
@@ -163,8 +166,9 @@ final class Cache {
 		foreach ( $sitemap->get_sitemap_endpoint_list() as $id => $data ) {
 			$transient = $sitemap->get_transient_key( $id );
 
-			if ( $transient )
+			if ( $transient ) {
 				$success[] = \delete_transient( $transient );
+			}
 		}
 
 		/**

--- a/inc/classes/bridges/feed.class.php
+++ b/inc/classes/bridges/feed.class.php
@@ -87,14 +87,17 @@ final class Feed {
 	 */
 	public function _init() {
 
-		if ( \The_SEO_Framework\has_run( __METHOD__ ) ) return;
+		if ( \The_SEO_Framework\has_run( __METHOD__ ) ) {
+			return;
+		}
 
 		// Alter the content feed.
 		\add_filter( 'the_content_feed', [ $this, '_modify_the_content_feed' ], 10, 2 );
 
 		// Only add the feed link to the excerpt if we're only building excerpts.
-		if ( \get_option( 'rss_use_excerpt' ) )
+		if ( \get_option( 'rss_use_excerpt' ) ) {
 			\add_filter( 'the_excerpt_rss', [ $this, '_modify_the_content_feed' ], 10, 1 );
+		}
 	}
 
 	/**
@@ -113,7 +116,9 @@ final class Feed {
 	public function _modify_the_content_feed( $content = '', $feed_type = null ) {
 
 		// When there's no content, there's nothing to modify or quote.
-		if ( ! $content ) return '';
+		if ( ! $content ) {
+			return '';
+		}
 
 		$tsf = \tsf();
 

--- a/inc/classes/bridges/listedit.class.php
+++ b/inc/classes/bridges/listedit.class.php
@@ -117,7 +117,9 @@ final class ListEdit extends ListTable {
 	 */
 	public function _display_bulk_edit_fields( $column_name, $post_type, $taxonomy = '' ) {
 
-		if ( $this->column_name !== $column_name ) return;
+		if ( $this->column_name !== $column_name ) {
+			return;
+		}
 
 		// phpcs:ignore, Generic.CodeAnalysis.EmptyStatement -- For the future, when WordPress Core decides.
 		if ( $taxonomy ) {
@@ -139,7 +141,9 @@ final class ListEdit extends ListTable {
 	 */
 	public function _display_quick_edit_fields( $column_name, $post_type, $taxonomy = '' ) {
 
-		if ( $this->column_name !== $column_name ) return;
+		if ( $this->column_name !== $column_name ) {
+			return;
+		}
 
 		if ( $taxonomy ) {
 			\tsf()->get_view( 'list/quick-term', get_defined_vars() );
@@ -163,7 +167,9 @@ final class ListEdit extends ListTable {
 		if (
 			   $this->column_name !== $column_name
 			|| ! \current_user_can( 'edit_post', $post_id )
-		) return;
+		) {
+			return;
+		}
 
 		$tsf = \tsf();
 
@@ -300,9 +306,9 @@ final class ListEdit extends ListTable {
 			HTML::make_data_attributes( [ 'leDescription' => $desc_data ] )
 		);
 
-		if ( $this->doing_ajax )
+		if ( $this->doing_ajax ) {
 			echo $this->get_ajax_dispatch_updated_event(); // phpcs:ignore, WordPress.Security.EscapeOutput
-	}
+		}	}
 
 	/**
 	 * Returns the quick edit data for terms.
@@ -322,8 +328,12 @@ final class ListEdit extends ListTable {
 	 */
 	public function _output_column_contents_for_term( $string, $column_name, $term_id ) {
 
-		if ( $this->column_name !== $column_name )          return $string;
-		if ( ! \current_user_can( 'edit_term', $term_id ) ) return $string;
+		if ( $this->column_name !== $column_name ) {
+			return $string;
+		}
+		if ( ! \current_user_can( 'edit_term', $term_id ) ) {
+			return $string;
+		}
 
 		$tsf = \tsf();
 
@@ -435,8 +445,9 @@ final class ListEdit extends ListTable {
 			HTML::make_data_attributes( [ 'leDescription' => $desc_data ] )
 		);
 
-		if ( $this->doing_ajax )
+		if ( $this->doing_ajax ) {
 			$container .= $this->get_ajax_dispatch_updated_event();
+		}
 
 		return "$string$container";
 	}

--- a/inc/classes/bridges/listtable.class.php
+++ b/inc/classes/bridges/listtable.class.php
@@ -100,13 +100,16 @@ abstract class ListTable {
 		if (
 			   ! \check_ajax_referer( 'add-tag', '_wpnonce_add-tag', false )
 			|| empty( $_POST['taxonomy'] )
-		) return;
+		) {
+			return;
+		}
 
 		$taxonomy   = stripslashes( $_POST['taxonomy'] );
 		$tax_object = $taxonomy ? \get_taxonomy( $taxonomy ) : false;
 
-		if ( $tax_object && \current_user_can( $tax_object->cap->edit_terms ) )
+		if ( $tax_object && \current_user_can( $tax_object->cap->edit_terms ) ) {
 			$this->init_columns_ajax();
+		}
 	}
 
 	/**
@@ -121,14 +124,17 @@ abstract class ListTable {
 			   ! \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false )
 			|| empty( $_POST['post_ID'] )
 			|| empty( $_POST['post_type'] )
-		) return;
+		) {
+			return;
+		}
 
 		$post_type = stripslashes( $_POST['post_type'] );
 		$pto       = $post_type ? \get_post_type_object( $post_type ) : false;
 
 		// TODO shouldn't we just use `edit_post`? See _output_column_contents_for_post && get_post_type_capabilities
-		if ( $pto && \current_user_can( "edit_{$pto->capability_type}", (int) $_POST['post_ID'] ) )
+		if ( $pto && \current_user_can( "edit_{$pto->capability_type}", (int) $_POST['post_ID'] ) ) {
 			$this->init_columns_ajax();
+		}
 	}
 
 	/**
@@ -143,10 +149,13 @@ abstract class ListTable {
 		if (
 			   ! \check_ajax_referer( 'taxinlineeditnonce', '_inline_edit', false )
 			|| empty( $_POST['tax_ID'] )
-		) return;
+		) {
+			return;
+		}
 
-		if ( \current_user_can( 'edit_term', (int) $_POST['tax_ID'] ) )
+		if ( \current_user_can( 'edit_term', (int) $_POST['tax_ID'] ) ) {
 			$this->init_columns_ajax();
+		}
 	}
 
 	/**
@@ -161,24 +170,29 @@ abstract class ListTable {
 		if (
 			   ! \tsf()->is_wp_lists_edit()
 			|| empty( $screen->id )
-		) return;
+		) {
+			return;
+		}
 
 		$post_type = $screen->post_type ?? '';
 		$taxonomy  = $screen->taxonomy ?? '';
 
 		if ( $taxonomy ) {
-			if ( ! \tsf()->is_taxonomy_supported( $taxonomy ) )
+			if ( ! \tsf()->is_taxonomy_supported( $taxonomy ) ) {
 				return;
+			}
 		} else {
-			if ( ! \tsf()->is_post_type_supported( $post_type ) )
+			if ( ! \tsf()->is_post_type_supported( $post_type ) ) {
 				return;
+			}
 		}
 
 		$this->post_type = $post_type;
 		$this->taxonomy  = $taxonomy;
 
-		if ( $taxonomy )
+		if ( $taxonomy ) {
 			\add_filter( "manage_{$taxonomy}_custom_column", [ $this, '_output_column_contents_for_term' ], 1, 3 );
+		}
 
 		\add_filter( "manage_{$screen->id}_columns", [ $this, '_add_column' ], 10, 1 );
 		/**
@@ -209,11 +223,13 @@ abstract class ListTable {
 				?: ( isset( $_POST['tax_type'] ) ? stripslashes( $_POST['tax_type'] ) : '' );
 
 		if ( $taxonomy ) {
-			if ( ! \tsf()->is_taxonomy_supported( $taxonomy ) )
+			if ( ! \tsf()->is_taxonomy_supported( $taxonomy ) ) {
 				return;
+			}
 		} else {
-			if ( ! \tsf()->is_post_type_supported( $post_type ) )
+			if ( ! \tsf()->is_post_type_supported( $post_type ) ) {
 				return;
+			}
 		}
 
 		$this->doing_ajax = true;
@@ -223,8 +239,9 @@ abstract class ListTable {
 		$screen_id = isset( $_POST['screen'] ) ? stripslashes( $_POST['screen'] ) : '';
 
 		// Not elseif; either request.
-		if ( $taxonomy )
+		if ( $taxonomy ) {
 			\add_filter( "manage_{$taxonomy}_custom_column", [ $this, '_output_column_contents_for_term' ], 1, 3 );
+		}
 
 		if ( $screen_id ) {
 			// Everything but inline-save-tax action.

--- a/inc/classes/bridges/ping.class.php
+++ b/inc/classes/bridges/ping.class.php
@@ -95,7 +95,9 @@ final class Ping {
 	 */
 	public static function retry_ping_search_engines( $args = [] ) {
 
-		if ( empty( $args['id'] ) || 'base' !== $args['id'] ) return;
+		if ( empty( $args['id'] ) || 'base' !== $args['id'] ) {
+			return;
+		}
 
 		static::ping_search_engines();
 	}
@@ -119,7 +121,9 @@ final class Ping {
 
 		$tsf = \tsf();
 
-		if ( $tsf->get_option( 'site_noindex' ) || ! $tsf->is_blog_public() ) return;
+		if ( $tsf->get_option( 'site_noindex' ) || ! $tsf->is_blog_public() ) {
+			return;
+		}
 
 		// Check for sitemap lock. If TSF's default sitemap isn't used, this should return false.
 		if ( \The_SEO_Framework\Bridges\Sitemap::get_instance()->is_sitemap_locked() ) {
@@ -136,11 +140,13 @@ final class Ping {
 			 */
 			\do_action( 'the_seo_framework_before_ping_search_engines', static::class );
 
-			if ( $tsf->get_option( 'ping_google' ) )
+			if ( $tsf->get_option( 'ping_google' ) ) {
 				static::ping_google();
+			}
 
-			if ( $tsf->get_option( 'ping_bing' ) )
+			if ( $tsf->get_option( 'ping_bing' ) ) {
 				static::ping_bing();
+			}
 
 			/**
 			 * @since 4.0.2
@@ -173,7 +179,9 @@ final class Ping {
 
 		$url = static::get_ping_url();
 
-		if ( ! $url ) return;
+		if ( ! $url ) {
+			return;
+		}
 
 		\wp_safe_remote_get(
 			'https://www.google.com/ping?sitemap=' . rawurlencode( $url ),
@@ -195,7 +203,9 @@ final class Ping {
 
 		$url = static::get_ping_url();
 
-		if ( ! $url ) return;
+		if ( ! $url ) {
+			return;
+		}
 
 		\wp_safe_remote_get(
 			'https://www.bing.com/ping?sitemap=' . rawurlencode( $url ),

--- a/inc/classes/bridges/plugintable.class.php
+++ b/inc/classes/bridges/plugintable.class.php
@@ -87,8 +87,9 @@ final class PluginTable {
 	 */
 	public static function _add_plugin_row_meta( $plugin_meta, $plugin_file ) {
 
-		if ( \THE_SEO_FRAMEWORK_PLUGIN_BASENAME !== $plugin_file )
+		if ( \THE_SEO_FRAMEWORK_PLUGIN_BASENAME !== $plugin_file ) {
 			return $plugin_meta;
+		}
 
 		$plugins = \get_plugins();
 		$_get_em = empty( $plugins['the-seo-framework-extension-manager/the-seo-framework-extension-manager.php'] );

--- a/inc/classes/bridges/postsettings.class.php
+++ b/inc/classes/bridges/postsettings.class.php
@@ -151,8 +151,9 @@ final class PostSettings {
 	 */
 	public static function _add_postbox_class( $classes = [] ) {
 
-		if ( \tsf()->is_gutenberg_page() )
+		if ( \tsf()->is_gutenberg_page() ) {
 			$classes[] = 'tsf-is-block-editor';
+		}
 
 		return $classes;
 	}

--- a/inc/classes/bridges/scripts.class.php
+++ b/inc/classes/bridges/scripts.class.php
@@ -92,11 +92,13 @@ final class Scripts {
 			$scripts[] = static::get_primaryterm_scripts();
 			$scripts[] = static::get_ays_scripts();
 
-			if ( $tsf->get_option( 'display_pixel_counter' ) || $tsf->get_option( 'display_character_counter' ) )
+			if ( $tsf->get_option( 'display_pixel_counter' ) || $tsf->get_option( 'display_character_counter' ) ) {
 				$scripts[] = static::get_counter_scripts();
+			}
 
-			if ( $tsf->is_gutenberg_page() )
+			if ( $tsf->is_gutenberg_page() ) {
 				$scripts[] = static::get_gutenberg_compat_scripts();
+			}
 		} elseif ( $tsf->is_term_edit() ) {
 			static::prepare_media_scripts();
 
@@ -107,15 +109,17 @@ final class Scripts {
 			$scripts[] = static::get_social_scripts();
 			$scripts[] = static::get_ays_scripts();
 
-			if ( $tsf->get_option( 'display_pixel_counter' ) || $tsf->get_option( 'display_character_counter' ) )
+			if ( $tsf->get_option( 'display_pixel_counter' ) || $tsf->get_option( 'display_character_counter' ) ) {
 				$scripts[] = static::get_counter_scripts();
+			}
 		} elseif ( $tsf->is_wp_lists_edit() ) {
 			$scripts[] = static::get_list_edit_scripts();
 			$scripts[] = static::get_title_scripts();
 			$scripts[] = static::get_description_scripts();
 
-			if ( $tsf->get_option( 'display_pixel_counter' ) || $tsf->get_option( 'display_character_counter' ) )
+			if ( $tsf->get_option( 'display_pixel_counter' ) || $tsf->get_option( 'display_character_counter' ) ) {
 				$scripts[] = static::get_counter_scripts();
+			}
 		} elseif ( $tsf->is_seo_settings_page() ) {
 			static::prepare_media_scripts();
 			static::prepare_metabox_scripts();
@@ -177,11 +181,13 @@ final class Scripts {
 	 */
 	public static function decode_all_entities( $values ) {
 
-		if ( is_scalar( $values ) )
+		if ( is_scalar( $values ) ) {
 			return static::decode_entities( $values );
+		}
 
-		foreach ( $values as &$v )
+		foreach ( $values as &$v ) {
 			$v = static::decode_entities( $v );
+		}
 
 		return $values;
 	}
@@ -196,8 +202,9 @@ final class Scripts {
 		$tsf  = \tsf();
 		$args = [];
 
-		if ( $tsf->is_post_edit() )
+		if ( $tsf->is_post_edit() ) {
 			$args['post'] = $tsf->get_the_real_admin_ID();
+		}
 
 		\wp_enqueue_media( $args );
 	}
@@ -737,7 +744,9 @@ final class Scripts {
 		$gutenberg = $tsf->is_gutenberg_page();
 
 		foreach ( $_taxonomies as $_t ) {
-			if ( ! $tsf->is_taxonomy_supported( $_t->name ) ) continue;
+			if ( ! $tsf->is_taxonomy_supported( $_t->name ) ) {
+				continue;
+			}
 
 			$singular_name   = $tsf->get_tax_type_label( $_t->name );
 			$primary_term_id = $tsf->get_primary_term_id( $id, $_t->name ) ?: 0;

--- a/inc/classes/bridges/seobar.class.php
+++ b/inc/classes/bridges/seobar.class.php
@@ -79,8 +79,9 @@ final class SEOBar extends ListTable {
 		foreach ( $order_keys as $key ) {
 			// Put value in $offset, if not false, break loop.
 			$offset = array_search( $key, $column_keys, true );
-			if ( false !== $offset )
+			if ( false !== $offset ) {
 				break;
+			}
 		}
 
 		// It tried but found nothing
@@ -115,7 +116,9 @@ final class SEOBar extends ListTable {
 	 */
 	public function _output_column_contents_for_post( $column_name, $post_id ) {
 
-		if ( $this->column_name !== $column_name ) return;
+		if ( $this->column_name !== $column_name ) {
+			return;
+		}
 
 		// phpcs:ignore, WordPress.Security.EscapeOutput
 		echo \The_SEO_Framework\Interpreters\SEOBar::generate_bar( [
@@ -123,9 +126,9 @@ final class SEOBar extends ListTable {
 			'post_type' => $this->post_type,
 		] );
 
-		if ( $this->doing_ajax )
+		if ( $this->doing_ajax ) {
 			echo $this->get_ajax_dispatch_updated_event(); // phpcs:ignore, WordPress.Security.EscapeOutput
-	}
+		}	}
 
 	/**
 	 * Returns the SEO Bar for terms.
@@ -145,10 +148,13 @@ final class SEOBar extends ListTable {
 	 */
 	public function _output_column_contents_for_term( $string, $column_name, $term_id ) {
 
-		if ( $this->column_name !== $column_name ) return $string;
+		if ( $this->column_name !== $column_name ) {
+			return $string;
+		}
 
-		if ( $this->doing_ajax )
+		if ( $this->doing_ajax ) {
 			$string .= $this->get_ajax_dispatch_updated_event();
+		}
 
 		return \The_SEO_Framework\Interpreters\SEOBar::generate_bar( [
 			'id'       => $term_id,

--- a/inc/classes/bridges/seosettings.class.php
+++ b/inc/classes/bridges/seosettings.class.php
@@ -72,7 +72,7 @@ final class SeoSettings {
 		$class = static::class;
 
 		// General Meta Box
-		if ( $general )
+		if ( $general ) {
 			\add_meta_box(
 				'autodescription-general-settings',
 				\esc_html__( 'General Settings', 'autodescription' ),
@@ -80,9 +80,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Title Meta Box
-		if ( $title )
+		if ( $title ) {
 			\add_meta_box(
 				'autodescription-title-settings',
 				\esc_html__( 'Title Settings', 'autodescription' ),
@@ -90,9 +91,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Description Meta Box
-		if ( $description )
+		if ( $description ) {
 			\add_meta_box(
 				'autodescription-description-settings',
 				\esc_html__( 'Description Meta Settings', 'autodescription' ),
@@ -100,9 +102,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Homepage Meta Box
-		if ( $home )
+		if ( $home ) {
 			\add_meta_box(
 				'autodescription-homepage-settings',
 				\esc_html__( 'Homepage Settings', 'autodescription' ),
@@ -110,8 +113,9 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
-		if ( $post_type_archive && $tsf->get_public_post_type_archives() )
+		if ( $post_type_archive && $tsf->get_public_post_type_archives() ) {
 			\add_meta_box(
 				'autodescription-post-type-archive-settings',
 				\esc_html__( 'Post Type Archive Settings', 'autodescription' ),
@@ -119,9 +123,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Social Meta Box
-		if ( $social )
+		if ( $social ) {
 			\add_meta_box(
 				'autodescription-social-settings',
 				\esc_html__( 'Social Meta Settings', 'autodescription' ),
@@ -129,9 +134,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Schema Meta Box
-		if ( $schema )
+		if ( $schema ) {
 			\add_meta_box(
 				'autodescription-schema-settings',
 				\esc_html__( 'Schema.org Settings', 'autodescription' ),
@@ -139,9 +145,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Robots Meta Box
-		if ( $robots )
+		if ( $robots ) {
 			\add_meta_box(
 				'autodescription-robots-settings',
 				\esc_html__( 'Robots Meta Settings', 'autodescription' ),
@@ -149,9 +156,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Webmaster Meta Box
-		if ( $webmaster )
+		if ( $webmaster ) {
 			\add_meta_box(
 				'autodescription-webmaster-settings',
 				\esc_html__( 'Webmaster Meta Settings', 'autodescription' ),
@@ -159,9 +167,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Sitemaps Meta Box
-		if ( $sitemap )
+		if ( $sitemap ) {
 			\add_meta_box(
 				'autodescription-sitemap-settings',
 				\esc_html__( 'Sitemap Settings', 'autodescription' ),
@@ -169,9 +178,10 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 
 		// Feed Meta Box
-		if ( $feed )
+		if ( $feed ) {
 			\add_meta_box(
 				'autodescription-feed-settings',
 				\esc_html__( 'Feed Settings', 'autodescription' ),
@@ -179,6 +189,7 @@ final class SeoSettings {
 				$settings_page_hook,
 				'main'
 			);
+		}
 	}
 
 	/**

--- a/inc/classes/bridges/sitemap.class.php
+++ b/inc/classes/bridges/sitemap.class.php
@@ -122,7 +122,9 @@ final class Sitemap {
 		}
 
 		// Probably home page.
-		if ( '/' === $raw_uri ) return;
+		if ( '/' === $raw_uri ) {
+			return;
+		}
 
 		// The path+query where sitemaps are served.
 		$path_info = static::get_sitemap_base_path_info();
@@ -131,12 +133,16 @@ final class Sitemap {
 		$path_regex = '/^' . preg_quote( rawurldecode( $path_info['path'] ), '/' ) . '/ui';
 
 		// See if the base matches the endpoint. This is crucial for query-based endpoints.
-		if ( ! preg_match( $path_regex, $raw_uri ) ) return;
+		if ( ! preg_match( $path_regex, $raw_uri ) ) {
+			return;
+		}
 
 		$stripped_uri = preg_replace( $path_regex, '', rtrim( $raw_uri, '/' ) );
 
 		// Strip the base URI. If nothing's left, stop assessing.
-		if ( ! $stripped_uri ) return;
+		if ( ! $stripped_uri ) {
+			return;
+		}
 
 		// Loop over the sitemap endpoints, and see if it matches the stripped uri.
 		if ( $path_info['use_query_var'] ) {
@@ -157,7 +163,9 @@ final class Sitemap {
 			}
 		}
 
-		if ( ! $this->sitemap_id ) return;
+		if ( ! $this->sitemap_id ) {
+			return;
+		}
 
 		static::$tsf->is_sitemap( true );
 		\add_action( 'pre_get_posts', [ static::class, '_override_query_parameters' ] );
@@ -212,7 +220,9 @@ final class Sitemap {
 
 		$list = $this->get_sitemap_endpoint_list();
 
-		if ( ! isset( $list[ $id ] ) ) return false;
+		if ( ! isset( $list[ $id ] ) ) {
+			return false;
+		}
 
 		$host      = static::$tsf->set_preferred_url_scheme( static::$tsf->get_home_host() );
 		$path_info = static::get_sitemap_base_path_info();
@@ -313,7 +323,9 @@ final class Sitemap {
 	 */
 	public static function refresh_sitemaps() {
 
-		if ( \The_SEO_Framework\has_run( __METHOD__ ) ) return false;
+		if ( \The_SEO_Framework\has_run( __METHOD__ ) ) {
+			return false;
+		}
 
 		Cache::clear_sitemap_transients();
 
@@ -359,7 +371,9 @@ final class Sitemap {
 		$sitemap_id = $sitemap_id ?: $this->sitemap_id;
 		$ep_list    = $this->get_sitemap_endpoint_list();
 
-		if ( ! isset( $ep_list[ $sitemap_id ] ) ) return false;
+		if ( ! isset( $ep_list[ $sitemap_id ] ) ) {
+			return false;
+		}
 
 		$cache_key = $ep_list[ $sitemap_id ]['cache_id'] ?? $sitemap_id;
 
@@ -381,7 +395,9 @@ final class Sitemap {
 
 		$transient_key = $this->get_transient_key( $sitemap_id );
 
-		if ( ! $transient_key ) return false;
+		if ( ! $transient_key ) {
+			return false;
+		}
 
 		return Cache::set_transient( $transient_key, $content, $expiration );
 	}
@@ -399,7 +415,9 @@ final class Sitemap {
 
 		$transient_key = $this->get_transient_key( $sitemap_id );
 
-		if ( ! $transient_key ) return false;
+		if ( ! $transient_key ) {
+			return false;
+		}
 
 		return Cache::get_transient( $transient_key );
 	}
@@ -418,7 +436,9 @@ final class Sitemap {
 		$sitemap_id = $sitemap_id ?: $this->sitemap_id;
 		$ep_list    = $this->get_sitemap_endpoint_list();
 
-		if ( ! isset( $ep_list[ $sitemap_id ] ) ) return false;
+		if ( ! isset( $ep_list[ $sitemap_id ] ) ) {
+			return false;
+		}
 
 		$lock_id = $ep_list[ $sitemap_id ]['lock_id'] ?? $sitemap_id;
 
@@ -468,7 +488,9 @@ final class Sitemap {
 
 		$lock_key = $this->get_lock_key( $sitemap_id ?: $this->sitemap_id );
 
-		if ( ! $lock_key ) return false;
+		if ( ! $lock_key ) {
+			return false;
+		}
 
 		$ini_max_execution_time = (int) ini_get( 'max_execution_time' );
 
@@ -758,7 +780,9 @@ final class Sitemap {
 	 */
 	private static function clean_up_globals( $get_freed_memory = false ) {
 
-		if ( $get_freed_memory ) return memo() ?? 0;
+		if ( $get_freed_memory ) {
+			return memo() ?? 0;
+		}
 
 		$memory = memory_get_usage();
 
@@ -782,8 +806,9 @@ final class Sitemap {
 
 		foreach ( $remove as $key => $value ) {
 			if ( \is_array( $value ) ) {
-				foreach ( $value as $v )
+				foreach ( $value as $v ) {
 					unset( $GLOBALS[ $key ][ $v ] );
+				}
 			} else {
 				unset( $GLOBALS[ $value ] );
 			}

--- a/inc/classes/bridges/usersettings.class.php
+++ b/inc/classes/bridges/usersettings.class.php
@@ -45,7 +45,9 @@ final class UserSettings {
 	 */
 	public static function _prepare_setting_fields( $user ) {
 
-		if ( ! $user->has_cap( \THE_SEO_FRAMEWORK_AUTHOR_INFO_CAP ) ) return;
+		if ( ! $user->has_cap( \THE_SEO_FRAMEWORK_AUTHOR_INFO_CAP ) ) {
+			return;
+		}
 
 		static::add_user_author_fields( $user );
 	}

--- a/inc/classes/builders/coresitemaps/main.class.php
+++ b/inc/classes/builders/coresitemaps/main.class.php
@@ -84,8 +84,9 @@ class Main extends \The_SEO_Framework\Builders\Sitemap\Main {
 		if ( isset( $wp_query->query_vars['sitemap'] ) ) {
 			// Didn't we request a simple API function for this? Anyway, null safe operators would also be nice here.
 			// For now, let's assume this API won't change. Test periodically.
-			if ( \wp_sitemaps_get_server()->registry->get_provider( $wp_query->query_vars['sitemap'] ) )
+			if ( \wp_sitemaps_get_server()->registry->get_provider( $wp_query->query_vars['sitemap'] ) ) {
 				\tsf()->is_sitemap( true );
+			}
 		}
 
 		return $args;
@@ -104,8 +105,9 @@ class Main extends \The_SEO_Framework\Builders\Sitemap\Main {
 	 */
 	public static function _filter_add_provider( $provider, $name ) {
 
-		if ( ! $provider instanceof \WP_Sitemaps_Provider )
+		if ( ! $provider instanceof \WP_Sitemaps_Provider ) {
 			return $provider;
+		}
 
 		switch ( $name ) {
 			case 'posts':
@@ -117,8 +119,9 @@ class Main extends \The_SEO_Framework\Builders\Sitemap\Main {
 			case 'users':
 				// This option is not reversible through means other than filters.
 				// static::$tsf isn't set, because static doesn't require instantiation here.
-				if ( \tsf()->get_option( 'author_noindex' ) )
+				if ( \tsf()->get_option( 'author_noindex' ) ) {
 					$provider = null;
+				}
 				break;
 			default:
 				break;

--- a/inc/classes/builders/coresitemaps/posts.class.php
+++ b/inc/classes/builders/coresitemaps/posts.class.php
@@ -58,8 +58,9 @@ class Posts extends \WP_Sitemaps_Posts {
 		// Bail early if the queried post type is not supported.
 		$supported_types = $this->get_object_subtypes();
 
-		if ( ! isset( $supported_types[ $post_type ] ) )
+		if ( ! isset( $supported_types[ $post_type ] ) ) {
 			return [];
+		}
 
 		/**
 		 * Filters the posts URL list before it is generated.
@@ -80,8 +81,9 @@ class Posts extends \WP_Sitemaps_Posts {
 			$page_num
 		);
 
-		if ( null !== $url_list )
+		if ( null !== $url_list ) {
 			return $url_list;
+		}
 
 		$args          = $this->get_posts_query_args( $post_type );
 		$args['paged'] = $page_num;
@@ -157,8 +159,9 @@ class Posts extends \WP_Sitemaps_Posts {
 			/**
 			 * @augmented This if-statement prevents including the post in the sitemap when conditions apply.
 			 */
-			if ( ! $main->is_post_included_in_sitemap( $post->ID ) )
+			if ( ! $main->is_post_included_in_sitemap( $post->ID ) ) {
 				continue;
+			}
 
 			$sitemap_entry = [
 				'loc' => \get_permalink( $post ),
@@ -170,8 +173,9 @@ class Posts extends \WP_Sitemaps_Posts {
 			if ( $show_modified ) {
 				$lastmod = $post->post_modified_gmt ?? '0000-00-00 00:00:00';
 
-				if ( '0000-00-00 00:00:00' !== $lastmod )
+				if ( '0000-00-00 00:00:00' !== $lastmod ) {
 					$sitemap_entry['lastmod'] = $tsf->gmt2date( $timestamp_format, $lastmod );
+				}
 			}
 
 			/**

--- a/inc/classes/builders/coresitemaps/taxonomies.class.php
+++ b/inc/classes/builders/coresitemaps/taxonomies.class.php
@@ -56,8 +56,9 @@ class Taxonomies extends \WP_Sitemaps_Taxonomies {
 		$supported_types = $this->get_object_subtypes();
 
 		// Bail early if the queried taxonomy is not supported.
-		if ( ! isset( $supported_types[ $taxonomy ] ) )
+		if ( ! isset( $supported_types[ $taxonomy ] ) ) {
 			return [];
+		}
 
 		/**
 		 * Filters the taxonomies URL list before it is generated.
@@ -78,8 +79,9 @@ class Taxonomies extends \WP_Sitemaps_Taxonomies {
 			$page_num
 		);
 
-		if ( null !== $url_list )
+		if ( null !== $url_list ) {
 			return $url_list;
+		}
 
 		$url_list = [];
 
@@ -98,13 +100,15 @@ class Taxonomies extends \WP_Sitemaps_Taxonomies {
 			/**
 			 * @augmented This if-statement prevents including the term in the sitemap when conditions apply.
 			 */
-			if ( ! $main->is_term_included_in_sitemap( $term->term_id, $taxonomy ) )
+			if ( ! $main->is_term_included_in_sitemap( $term->term_id, $taxonomy ) ) {
 				continue;
+			}
 
 			$term_link = \get_term_link( $term, $taxonomy );
 
-			if ( \is_wp_error( $term_link ) )
+			if ( \is_wp_error( $term_link ) ) {
 				continue;
+			}
 
 			$sitemap_entry = [
 				'loc' => $term_link,

--- a/inc/classes/builders/images.class.php
+++ b/inc/classes/builders/images.class.php
@@ -175,13 +175,17 @@ final class Images {
 		if ( $matches ) {
 			for ( $i = 0; $i < static::MAX_CONTENT_IMAGES; $i++ ) {
 				// Fewer than MAX_CONTENT_IMAGES matched.
-				if ( ! isset( $matches[ $i ][2] ) ) break;
+				if ( ! isset( $matches[ $i ][2] ) ) {
+					break;
+				}
 
 				// Assume every URL to be correct? Yes. WordPress assumes that too.
 				$url = $matches[ $i ][2];
 
 				// false-esque matches, like '0', are so uncommon it's not worth dealing with them.
-				if ( ! $url ) continue;
+				if ( ! $url ) {
+					continue;
+				}
 
 				yield [
 					'url' => $url,

--- a/inc/classes/builders/robots/args.class.php
+++ b/inc/classes/builders/robots/args.class.php
@@ -92,30 +92,34 @@ final class Args extends Factory {
 			yield 'globals_site' => (bool) $tsf->get_option( "site_$type" );
 
 			if ( $args['taxonomy'] ) {
-				$asserting_noindex and yield from static::assert_noindex_query_pass( '404' );
+			$asserting_noindex and yield from static::assert_noindex_query_pass( '404' );
 
-				yield 'globals_taxonomy' => $tsf->is_taxonomy_robots_set( $type, $args['taxonomy'] );
+			yield 'globals_taxonomy' => $tsf->is_taxonomy_robots_set( $type, $args['taxonomy'] );
 
-				// Store values from each post type bound to the taxonomy.
-				foreach ( $tsf->get_post_types_from_taxonomy( $args['taxonomy'] ) as $post_type )
-					$_is_post_type_robots_set[] = $tsf->is_post_type_robots_set( $type, $post_type );
+			// Store values from each post type bound to the taxonomy.
+			foreach ( $tsf->get_post_types_from_taxonomy( $args['taxonomy'] ) as $post_type ) {
+				$_is_post_type_robots_set[] = $tsf->is_post_type_robots_set( $type, $post_type );
+				}
 
-				// Only enable if _all_ post types have been marked with 'no*'. Return false if no post types are found (corner case).
-				yield 'globals_post_type_all' => isset( $_is_post_type_robots_set ) && ! \in_array( false, $_is_post_type_robots_set, true );
+			// Only enable if _all_ post types have been marked with 'no*'. Return false if no post types are found (corner case).
+			yield 'globals_post_type_all' => isset( $_is_post_type_robots_set ) && ! \in_array( false, $_is_post_type_robots_set, true );
 			} elseif ( $args['pta'] ) {
-				yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, $args['pta'] );
+			yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, $args['pta'] );
 			} else {
-				// $args['id'] can be empty, pointing to a plausible homepage query.
-				if ( $tsf->is_real_front_page_by_id( $args['id'] ) )
-					yield 'globals_homepage' => (bool) $tsf->get_option( "homepage_$type" );
+			// $args['id'] can be empty, pointing to a plausible homepage query.
+			if ( $tsf->is_real_front_page_by_id( $args['id'] ) ) {
+				yield 'globals_homepage' => (bool) $tsf->get_option( "homepage_$type" );
+				}
 
-				if ( $args['id'] )
-					yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, \get_post_type( $args['id'] ) );
+			if ( $args['id'] ) {
+				yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, \get_post_type( $args['id'] ) );
+				}
 			}
 
 		index_protection: if ( $asserting_noindex && ! ( static::$options & \The_SEO_Framework\ROBOTS_IGNORE_PROTECTION ) ) {
-			if ( ! $args['taxonomy'] )
+			if ( ! $args['taxonomy'] ) {
 				yield from static::assert_noindex_query_pass( 'protected' );
+			}
 		}
 
 		end:;

--- a/inc/classes/builders/robots/factory.class.php
+++ b/inc/classes/builders/robots/factory.class.php
@@ -104,35 +104,37 @@ class Factory {
 	 */
 	public static function generator() {
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition.Found -- Shhh. It's OK.
-		while ( true ) switch ( $sender = yield static::START ) :
-			case 'noindex':
-			case 'nofollow':
-			case 'noarchive':
-				foreach ( static::assert_no( $sender ) as $key => $value ) {
-					yield $key => $value;
-					if ( $value ) {
-						yield static::HALT;
-						break;
+		while ( true ) {
+			switch ( $sender = yield static::START ) :
+				case 'noindex':
+				case 'nofollow':
+				case 'noarchive':
+					foreach ( static::assert_no( $sender ) as $key => $value ) {
+						yield $key => $value;
+						if ( $value ) {
+							yield static::HALT;
+							break;
+						}
 					}
-				}
-				break;
+							break;
 
-			case 'max_snippet':
-			case 'max_image_preview':
-			case 'max_video_preview':
-				yield from static::assert_copyright( $sender );
-				yield static::HALT;
-				break;
+				case 'max_snippet':
+				case 'max_image_preview':
+				case 'max_video_preview':
+					yield from static::assert_copyright( $sender );
+					yield static::HALT;
+							break;
 
-			default:
-				static::$tsf->_doing_it_wrong(
+				default:
+					static::$tsf->_doing_it_wrong(
 					__METHOD__,
 					sprintf( 'Unregistered robots-generator getter provided: <code>%s</code>.', \esc_html( $sender ) ),
 					'4.2.0'
-				);
-				yield static::HALT;
-				break;
-		endswitch;
+					);
+					yield static::HALT;
+							break;
+		endswitch; 
+		};
 	}
 
 	/**
@@ -151,8 +153,9 @@ class Factory {
 
 		$option = $type;
 
-		if ( 'max_snippet' === $type )
+		if ( 'max_snippet' === $type ) {
 			$option = 'max_snippet_length';
+		}
 
 		$tsf->get_option( 'set_copyright_directives' )
 			and yield 'globals_copyright' => $tsf->get_option( $option );

--- a/inc/classes/builders/robots/main.class.php
+++ b/inc/classes/builders/robots/main.class.php
@@ -148,7 +148,9 @@ final class Main {
 
 			do {
 				// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition.Found -- Shhh. It's OK. I'm a professional.
-				if ( ( $r = $generator->current() ) === $halt ) continue; // goto while() -- motivating generator.
+				if ( ( $r = $generator->current() ) === $halt ) {
+					continue; // goto while() -- motivating generator.
+				}
 
 				$results[ $g ] = $r;
 

--- a/inc/classes/builders/robots/query.class.php
+++ b/inc/classes/builders/robots/query.class.php
@@ -94,37 +94,38 @@ final class Query extends Factory {
 			yield 'globals_site' => (bool) $tsf->get_option( "site_$type" );
 
 			if ( $tsf->is_real_front_page() ) {
-				yield 'globals_homepage' => (bool) $tsf->get_option( "homepage_$type" );
+			yield 'globals_homepage' => (bool) $tsf->get_option( "homepage_$type" );
 			} else {
-				$asserting_noindex and yield from static::assert_noindex_query_pass( '404' );
+			$asserting_noindex and yield from static::assert_noindex_query_pass( '404' );
 
-				if ( $tsf->is_archive() ) {
-					if ( $tsf->is_author() ) {
-						yield 'globals_author' => (bool) $tsf->get_option( "author_$type" );
+			if ( $tsf->is_archive() ) {
+				if ( $tsf->is_author() ) {
+					yield 'globals_author' => (bool) $tsf->get_option( "author_$type" );
 					} elseif ( \is_date() ) {
-						yield 'globals_date' => (bool) $tsf->get_option( "date_$type" );
+					yield 'globals_date' => (bool) $tsf->get_option( "date_$type" );
 					}
 				} elseif ( $tsf->is_search() ) {
-					yield 'globals_search' => (bool) $tsf->get_option( "search_$type" );
+				yield 'globals_search' => (bool) $tsf->get_option( "search_$type" );
 				}
 			}
 
 			// is_real_front_page() can still be singular or archive. Thus, this conditional block is split up.
 			if ( $tsf->is_archive() ) {
-				if ( $tsf->is_category() || $tsf->is_tag() || $tsf->is_tax() ) {
-					yield 'globals_taxonomy' => $tsf->is_taxonomy_robots_set( $type, $tsf->get_current_taxonomy() );
+			if ( $tsf->is_category() || $tsf->is_tag() || $tsf->is_tax() ) {
+				yield 'globals_taxonomy' => $tsf->is_taxonomy_robots_set( $type, $tsf->get_current_taxonomy() );
 
-					// Store values from each post type bound to the taxonomy.
-					foreach ( $tsf->get_post_types_from_taxonomy() as $post_type )
-						$_is_post_type_robots_set[] = $tsf->is_post_type_robots_set( $type, $post_type );
+				// Store values from each post type bound to the taxonomy.
+				foreach ( $tsf->get_post_types_from_taxonomy() as $post_type ) {
+					$_is_post_type_robots_set[] = $tsf->is_post_type_robots_set( $type, $post_type );
+					}
 
-					// Only enable if _all_ post types have been marked with 'no*'. Return false if no post types are found (corner case).
-					yield 'globals_post_type_all' => isset( $_is_post_type_robots_set ) && ! \in_array( false, $_is_post_type_robots_set, true );
+				// Only enable if _all_ post types have been marked with 'no*'. Return false if no post types are found (corner case).
+				yield 'globals_post_type_all' => isset( $_is_post_type_robots_set ) && ! \in_array( false, $_is_post_type_robots_set, true );
 				} elseif ( \is_post_type_archive() ) {
-					yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, $tsf->get_current_post_type() );
+				yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, $tsf->get_current_post_type() );
 				}
 			} elseif ( $tsf->is_singular() ) {
-				yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, $tsf->get_current_post_type() );
+			yield 'globals_post_type' => $tsf->is_post_type_robots_set( $type, $tsf->get_current_post_type() );
 			}
 
 		// We assert options here for a jump to index_protection might be unaware.
@@ -142,14 +143,16 @@ final class Query extends Factory {
 				 * and 'default_comments_page' via `redirect_canonical()`, so we don't have to.
 				 * For reference, it fires `remove_query_arg( 'cpage', $redirect['query'] )`;
 				 */
-				if ( (int) \get_query_var( 'cpage', 0 ) > 0 )
+				if ( (int) \get_query_var( 'cpage', 0 ) > 0 ) {
 					yield from static::assert_noindex_query_pass( 'cpage' );
+				}
 			}
 		}
 
 		exploit_protection: if ( $tsf->is_query_exploited() ) {
-			if ( \in_array( $type, [ 'noindex', 'nofollow' ], true ) )
+			if ( \in_array( $type, [ 'noindex', 'nofollow' ], true ) ) {
 				yield 'query_protection' => true;
+			}
 		}
 
 		end:;

--- a/inc/classes/builders/scripts.class.php
+++ b/inc/classes/builders/scripts.class.php
@@ -191,7 +191,9 @@ final class Scripts {
 	 */
 	public static function footer_enqueue() {
 
-		if ( \The_SEO_Framework\has_run( __METHOD__ ) ) return;
+		if ( \The_SEO_Framework\has_run( __METHOD__ ) ) {
+			return;
+		}
 
 		\add_action( 'admin_footer', [ static::class, 'enqueue' ], 998 ); // Magic number: 1 before output_templates.
 	}
@@ -233,7 +235,9 @@ final class Scripts {
 	public static function register( $script ) {
 		// This is 350x faster than a polyfill for `array_is_list()`.
 		if ( array_values( $script ) === $script ) {
-			foreach ( $script as $s ) static::register( $s );
+			foreach ( $script as $s ) {
+				static::register( $s );
+			}
 			return;
 		}
 
@@ -251,8 +255,9 @@ final class Scripts {
 	public static function forward_known_script( $id, $type ) {
 		if ( ! ( static::get_status_of( $id, $type ) & static::REGISTERED ) ) {
 			foreach ( static::$scripts as $s ) {
-				if ( $s['id'] === $id && $s['type'] === $type )
+				if ( $s['id'] === $id && $s['type'] === $type ) {
 					static::forward_script( $s );
+				}
 			}
 		}
 	}
@@ -272,8 +277,9 @@ final class Scripts {
 
 		$status = static::get_status_of( $id, $type );
 
-		if ( ( $status & static::REGISTERED ) && ! ( $status & static::LOADED ) )
+		if ( ( $status & static::REGISTERED ) && ! ( $status & static::LOADED ) ) {
 			static::load_script( $id, $type );
+		}
 	}
 
 	/**
@@ -303,7 +309,9 @@ final class Scripts {
 	private function forward_known_scripts() {
 		// Register them first to accommodate for dependencies.
 		foreach ( static::$scripts as $s ) {
-			if ( static::get_status_of( $s['id'], $s['type'] ) & static::REGISTERED ) continue;
+			if ( static::get_status_of( $s['id'], $s['type'] ) & static::REGISTERED ) {
+				continue;
+			}
 			static::forward_script( $s );
 		}
 	}
@@ -318,7 +326,9 @@ final class Scripts {
 	private function autoload_known_scripts() {
 		foreach ( static::$scripts as $s ) {
 			if ( $s['autoload'] ) {
-				if ( static::get_status_of( $s['id'], $s['type'] ) & static::LOADED ) continue;
+				if ( static::get_status_of( $s['id'], $s['type'] ) & static::LOADED ) {
+					continue;
+				}
 				static::load_script( $s['id'], $s['type'] );
 			}
 		}
@@ -377,7 +387,9 @@ final class Scripts {
 	 */
 	private static function load_script( $id, $type ) {
 
-		if ( ! ( static::get_status_of( $id, $type ) & static::REGISTERED ) ) return;
+		if ( ! ( static::get_status_of( $id, $type ) & static::REGISTERED ) ) {
+			return;
+		}
 
 		$loaded = false;
 
@@ -461,8 +473,9 @@ final class Scripts {
 
 		$out = '';
 
-		foreach ( $scripts as $script )
+		foreach ( $scripts as $script ) {
 			$out .= ";$script";
+		}
 
 		return $out;
 	}
@@ -534,8 +547,9 @@ final class Scripts {
 	 */
 	private function register_template( $id, $templates ) {
 		// Wrap template if it's only one on the base.
-		if ( isset( $templates['file'] ) )
+		if ( isset( $templates['file'] ) ) {
 			$templates = [ $templates ];
+		}
 
 		foreach ( $templates as $t ) {
 			static::$templates[ $id ][] = [
@@ -566,8 +580,9 @@ final class Scripts {
 				// Unset template before the loop, to prevent an infinite loop.
 				unset( static::$templates[ $id ] );
 
-				foreach ( $templates as $t )
+				foreach ( $templates as $t ) {
 					$this->output_view( $t[0], $t[1] );
+				}
 			}
 		}
 	}
@@ -589,8 +604,9 @@ final class Scripts {
 	 */
 	private function output_view( $file, $args ) {
 
-		foreach ( $args as $_key => $_val )
+		foreach ( $args as $_key => $_val ) {
 			$$_key = $_val;
+		}
 		unset( $_key, $_val, $args );
 
 		// Prevents private-includes hijacking.

--- a/inc/classes/builders/seobar/main.class.php
+++ b/inc/classes/builders/seobar/main.class.php
@@ -183,11 +183,13 @@ abstract class Main {
 
 		$this->prime_query_cache( $this->query_cache );
 
-		if ( \in_array( 'redirect', $tests, true ) && $this->has_blocking_redirect() )
+		if ( \in_array( 'redirect', $tests, true ) && $this->has_blocking_redirect() ) {
 			$tests = [ 'redirect' ];
+		}
 
-		foreach ( $tests as $test )
+		foreach ( $tests as $test ) {
 			yield $test => $this->{"test_$test"}();
+		}
 	}
 
 	/**

--- a/inc/classes/builders/seobar/page.class.php
+++ b/inc/classes/builders/seobar/page.class.php
@@ -259,8 +259,9 @@ final class Page extends Main {
 		if ( static::$tsf->use_title_protection( $_generator_args ) ) {
 			$_title_before = $title;
 			static::$tsf->merge_title_protection( $title, $_generator_args );
-			if ( $title !== $_title_before )
+			if ( $title !== $_title_before ) {
 				$item['assess']['protected'] = $cache['assess']['protected'];
+			}
 		}
 
 		if ( static::$tsf->use_title_branding( $_generator_args ) ) {
@@ -1003,8 +1004,9 @@ final class Page extends Main {
 				]
 			);
 
-			if ( $this->query_cache['states']['isdraft'] )
+			if ( $this->query_cache['states']['isdraft'] ) {
 				$default['assess']['redirect'] = \__( 'Visitors and crawlers may view this page once published.', 'autodescription' );
+			}
 
 			return $default;
 		} else {

--- a/inc/classes/builders/sitemap/base.class.php
+++ b/inc/classes/builders/sitemap/base.class.php
@@ -65,17 +65,24 @@ class Base extends Main {
 
 		$bridge = \The_SEO_Framework\Bridges\Sitemap::get_instance();
 
-		if ( ! $bridge->sitemap_cache_enabled() ) return;
+		if ( ! $bridge->sitemap_cache_enabled() ) {
+			return;
+		}
 
 		// Don't prerender if the sitemap is already generated.
-		if ( false !== $bridge->get_cached_sitemap( $sitemap_id ) ) return;
+		if ( false !== $bridge->get_cached_sitemap( $sitemap_id ) ) {
+			return;
+		}
 
 		$ini_max_execution_time = (int) ini_get( 'max_execution_time' );
-		if ( 0 !== $ini_max_execution_time )
+		if ( 0 !== $ini_max_execution_time ) {
 			set_time_limit( max( $ini_max_execution_time, 3 * \MINUTE_IN_SECONDS ) );
+		}
 
 		// Somehow, the 'base' key is unavailable, the database failed, or a lock is already in place. Either way, bail.
-		if ( ! $bridge->lock_sitemap( $sitemap_id ) ) return;
+		if ( ! $bridge->lock_sitemap( $sitemap_id ) ) {
+			return;
+		}
 
 		$this->prepare_generation();
 		$this->base_is_prerendering = true;
@@ -166,7 +173,7 @@ class Base extends Main {
 		 */
 		$timestamp = (bool) \apply_filters( 'the_seo_framework_sitemap_timestamp', true );
 
-		if ( $timestamp )
+		if ( $timestamp ) {
 			$content .= sprintf(
 				'<!-- %s -->',
 				sprintf(
@@ -178,6 +185,7 @@ class Base extends Main {
 					\current_time( 'Y-m-d H:i:s \G\M\T' )
 				)
 			) . "\n";
+		}
 
 		foreach ( $this->generate_front_and_blog_url_items(
 			compact( 'show_modified' ),
@@ -298,7 +306,9 @@ class Base extends Main {
 		$total_items = \count( $_items );
 
 		// 49998 = 50000-2 (home+blog), max sitemap items.
-		if ( $total_items > 49998 ) array_splice( $_items, 49998 );
+		if ( $total_items > 49998 ) {
+			array_splice( $_items, 49998 );
+		}
 		// We could also calculate the sitemap length (may not be above 10 MB)...
 		// ...but that'd mean each entry must be at least 200 chars long on avg. Good luck with that.
 
@@ -343,8 +353,9 @@ class Base extends Main {
 			]
 		);
 
-		if ( $extend )
+		if ( $extend ) {
 			$content .= "\t$extend\n";
+		}
 
 		return $content;
 	}
@@ -483,8 +494,9 @@ class Base extends Main {
 					'loc' => static::$tsf->get_canonical_url( [ 'id' => $post_id ] ),
 				];
 
-				if ( $args['show_modified'] )
+				if ( $args['show_modified'] ) {
 					$_values['lastmod'] = $post->post_modified_gmt ?? '0000-00-00 00:00:00';
+				}
 
 				++$count;
 				yield $_values;
@@ -510,7 +522,9 @@ class Base extends Main {
 	 */
 	protected function build_url_item( $args ) {
 
-		if ( empty( $args['loc'] ) ) return '';
+		if ( empty( $args['loc'] ) ) {
+			return '';
+		}
 
 		$xml = [
 			'loc' => $args['loc'], // Already escaped.
@@ -574,14 +588,17 @@ class Base extends Main {
 			}
 
 			// Test if URL is valid.
-			if ( ! \esc_url_raw( $url, [ 'https', 'http' ] ) ) continue;
+			if ( ! \esc_url_raw( $url, [ 'https', 'http' ] ) ) {
+				continue;
+			}
 
 			// Reset.
 			$_values        = [];
 			$_values['loc'] = $url;
 
-			if ( $args['show_modified'] )
+			if ( $args['show_modified'] ) {
 				$_values['lastmod'] = ! empty( $values['lastmod'] ) ? $values['lastmod'] : '0000-00-00 00:00:00';
+			}
 
 			++$count;
 			yield $_values;

--- a/inc/classes/builders/sitemap/main.class.php
+++ b/inc/classes/builders/sitemap/main.class.php
@@ -131,8 +131,9 @@ abstract class Main {
 		foreach ( $data as $key => $value ) {
 			$tabs = str_repeat( "\t", $level );
 
-			if ( \is_array( $value ) )
+			if ( \is_array( $value ) ) {
 				$value = "\n{$this->create_xml_entry( $value, $level + 1 )}$tabs";
+			}
 
 			$out .= "$tabs<$key>$value</$key>\n";
 		}
@@ -189,7 +190,9 @@ abstract class Main {
 						?? false // We cast type false for Zend tests strict type before identical-string-comparing.
 				);
 
-			if ( ! $included ) break;
+			if ( ! $included ) {
+				break;
+			}
 
 			// This is less likely than a "noindex," even though it's faster to process, we put it later.
 			$included = ! static::$tsf->get_redirect_url( $_generator_args );
@@ -245,7 +248,9 @@ abstract class Main {
 						?? false // We cast type false for Zend tests strict type before identical-string-comparing.
 				);
 
-			if ( ! $included ) break;
+			if ( ! $included ) {
+				break;
+			}
 
 			// This is less likely than a "noindex," even though it's faster to process, we put it later.
 			$included = ! static::$tsf->get_redirect_url( $_generator_args );

--- a/inc/classes/core.class.php
+++ b/inc/classes/core.class.php
@@ -78,8 +78,9 @@ class Core {
 		$this->_inaccessible_p_or_m( "tsf()->$name", 'unknown' );
 
 		// Invoke default behavior: Write variable if it's not protected.
-		if ( ! isset( $this->$name ) )
+		if ( ! isset( $this->$name ) ) {
 			$this->$name = $value;
+		}
 	}
 
 	/**
@@ -117,11 +118,13 @@ class Core {
 
 		static $depr_class = null;
 
-		if ( \is_null( $depr_class ) )
+		if ( \is_null( $depr_class ) ) {
 			$depr_class = new Internal\Deprecated;
+		}
 
-		if ( \is_callable( [ $depr_class, $name ] ) )
+		if ( \is_callable( [ $depr_class, $name ] ) ) {
 			return \call_user_func_array( [ $depr_class, $name ], $arguments );
+		}
 
 		$this->_inaccessible_p_or_m( "tsf()->$name()" );
 	}
@@ -140,7 +143,9 @@ class Core {
 		$level = ob_get_level();
 
 		if ( $level ) {
-			while ( $level-- ) ob_end_clean();
+			while ( $level-- ) {
+				ob_end_clean();
+			}
 			return true;
 		}
 
@@ -160,7 +165,9 @@ class Core {
 	public function _include_compat( $what, $type = 'plugin' ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo( null, $what, $type ) ) return $memo;
+		if ( null !== $memo = memo( null, $what, $type ) ) {
+			return $memo;
+		}
 		unset( $memo );
 
 		// phpcs:ignore, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- forwarded to include...
@@ -189,7 +196,9 @@ class Core {
 	public function get_view( $view, $__args = [], $instance = 'main' ) {
 
 		// A faster extract().
-		foreach ( $__args as $__k => $__v ) $$__k = $__v;
+		foreach ( $__args as $__k => $__v ) {
+			$$__k = $__v;
+		}
 		unset( $__k, $__v, $__args );
 
 		// phpcs:ignore, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- forwarded to include...
@@ -341,13 +350,15 @@ class Core {
 	 */
 	public function current_blog_is_spam_or_deleted() {
 
-		if ( ! \function_exists( '\\get_site' ) || ! \is_multisite() )
+		if ( ! \function_exists( '\\get_site' ) || ! \is_multisite() ) {
 			return false;
+		}
 
 		$site = \get_site();
 
-		if ( $site instanceof \WP_Site && ( '1' === $site->spam || '1' === $site->deleted ) )
+		if ( $site instanceof \WP_Site && ( '1' === $site->spam || '1' === $site->deleted ) ) {
 			return true;
+		}
 
 		return false;
 	}
@@ -475,7 +486,9 @@ class Core {
 
 		// We can later use `!array_is_list()`.
 		// This is 350x faster than a polyfill for `!array_is_list()`.
-		if ( [] === $array || array_values( $array ) !== $array ) return $array;
+		if ( [] === $array || array_values( $array ) !== $array ) {
+			return $array;
+		}
 
 		$ret = [];
 
@@ -513,10 +526,11 @@ class Core {
 		while ( --$i ) {
 			$p = $i - 1;
 
-			foreach ( $arrays[ $i ] as $key => $value )
+			foreach ( $arrays[ $i ] as $key => $value ) {
 				$arrays[ $p ][ $key ] = isset( $arrays[ $p ][ $key ] ) && \is_array( $value )
 					? $this->array_merge_recursive_distinct( $arrays[ $p ][ $key ], $value )
 					: $value;
+			}
 		}
 
 		return $arrays[0];
@@ -536,8 +550,9 @@ class Core {
 	 */
 	public function hellip_if_over( $string, $over = 0 ) {
 
-		if ( $over > 0 && \strlen( $string ) > $over )
+		if ( $over > 0 && \strlen( $string ) > $over ) {
 			$string = substr( $string, 0, abs( $over - 2 ) ) . '&hellip;';
+		}
 
 		return $string;
 	}
@@ -572,7 +587,9 @@ class Core {
 
 		$string = \wp_check_invalid_utf8( html_entity_decode( $string ) );
 
-		if ( ! $string ) return [];
+		if ( ! $string ) {
+			return [];
+		}
 
 		// Not if-function-exists; we're going for speed over accuracy. Hosts must do their job correctly.
 		$use_mb = memo( null, 'use_mb' ) ?? memo( \extension_loaded( 'mbstring' ), 'use_mb' );
@@ -584,12 +601,15 @@ class Core {
 			\PREG_SPLIT_OFFSET_CAPTURE | \PREG_SPLIT_NO_EMPTY
 		);
 
-		if ( ! \count( $word_list ) ) goto end;
+		if ( ! \count( $word_list ) ) {
+			goto end;
+		}
 
 		$words = [];
 
-		foreach ( $word_list as [ $_word, $_position ] )
+		foreach ( $word_list as [ $_word, $_position ] ) {
 			$words[ $_position ] = $_word;
+		}
 
 		// We're going to fetch words based on position, and then flip it to become the key.
 		$word_keys = array_flip( array_reverse( $words, true ) );

--- a/inc/classes/detect.class.php
+++ b/inc/classes/detect.class.php
@@ -46,7 +46,9 @@ class Detect extends Render {
 	public function active_plugins() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$active_plugins = (array) \get_option( 'active_plugins', [] );
 
@@ -55,8 +57,9 @@ class Detect extends Render {
 			// whereas active_plugins stores them in the values. array_keys() resolves the disparity.
 			$network_plugins = array_keys( \get_site_option( 'active_sitewide_plugins', [] ) );
 
-			if ( $network_plugins )
+			if ( $network_plugins ) {
 				$active_plugins = array_merge( $active_plugins, $network_plugins );
+			}
 		}
 
 		sort( $active_plugins );
@@ -146,24 +149,32 @@ class Detect extends Render {
 	 */
 	public function detect_plugin( $plugins ) {
 
-		foreach ( $plugins['globals'] ?? [] as $name )
-			if ( isset( $GLOBALS[ $name ] ) )
+		foreach ( $plugins['globals'] ?? [] as $name ) {
+			if ( isset( $GLOBALS[ $name ] ) ) {
 				return true;
+			}
+		}
 
 		// Check for constants
-		foreach ( $plugins['constants'] ?? [] as $name )
-			if ( \defined( $name ) )
+		foreach ( $plugins['constants'] ?? [] as $name ) {
+			if ( \defined( $name ) ) {
 				return true;
+			}
+		}
 
 		// Check for functions
-		foreach ( $plugins['functions'] ?? [] as $name )
-			if ( \function_exists( $name ) )
+		foreach ( $plugins['functions'] ?? [] as $name ) {
+			if ( \function_exists( $name ) ) {
 				return true;
+			}
+		}
 
 		// Check for classes
-		foreach ( $plugins['classes'] ?? [] as $name )
-			if ( class_exists( $name, false ) ) // phpcs:ignore, TSF.Performance.Functions.PHP -- we don't autoload.
+		foreach ( $plugins['classes'] ?? [] as $name ) {
+			if ( class_exists( $name, false ) ) { // phpcs:ignore, TSF.Performance.Functions.PHP -- we don't autoload.
 				return true;
+			}
+		}
 
 		// No globals, constant, function, or class found to exist
 		return false;
@@ -185,13 +196,15 @@ class Detect extends Render {
 	 */
 	public function can_i_use( $plugins = [], $use_cache = true ) {
 
-		if ( ! $use_cache )
+		if ( ! $use_cache ) {
 			return $this->detect_plugin_multi( $plugins );
+		}
 
 		ksort( $plugins );
 
-		foreach ( $plugins as &$test )
+		foreach ( $plugins as &$test ) {
 			sort( $test );
+		}
 
 		// phpcs:ignore, WordPress.PHP.DiscouragedPHPFunctions -- No objects are inserted, nor is this ever unserialized.
 		$key = serialize( $test );
@@ -218,24 +231,32 @@ class Detect extends Render {
 	public function detect_plugin_multi( $plugins ) {
 
 		// Check for globals
-		foreach ( $plugins['globals'] ?? [] as $name )
-			if ( ! isset( $GLOBALS[ $name ] ) )
+		foreach ( $plugins['globals'] ?? [] as $name ) {
+			if ( ! isset( $GLOBALS[ $name ] ) ) {
 				return false;
+			}
+		}
 
 		// Check for constants
-		foreach ( $plugins['constants'] ?? [] as $name )
-			if ( ! \defined( $name ) )
+		foreach ( $plugins['constants'] ?? [] as $name ) {
+			if ( ! \defined( $name ) ) {
 				return false;
+			}
+		}
 
 		// Check for functions
-		foreach ( $plugins['functions'] ?? [] as $name )
-			if ( ! \function_exists( $name ) )
+		foreach ( $plugins['functions'] ?? [] as $name ) {
+			if ( ! \function_exists( $name ) ) {
 				return false;
+			}
+		}
 
 		// Check for classes
-		foreach ( $plugins['classes'] ?? [] as $name )
-			if ( ! class_exists( $name, false ) ) // phpcs:ignore, TSF.Performance.Functions.PHP -- we don't autoload.
+		foreach ( $plugins['classes'] ?? [] as $name ) {
+			if ( ! class_exists( $name, false ) ) { // phpcs:ignore, TSF.Performance.Functions.PHP -- we don't autoload.
 				return false;
+			}
+		}
 
 		// All classes, functions and constant have been found to exist
 		return true;
@@ -257,9 +278,11 @@ class Detect extends Render {
 			strtolower( \get_option( 'template' ) ),   // Child
 		];
 
-		foreach ( (array) $themes as $theme )
-			if ( \in_array( strtolower( $theme ), $active_theme, true ) )
+		foreach ( (array) $themes as $theme ) {
+			if ( \in_array( strtolower( $theme ), $active_theme, true ) ) {
 				return true;
+			}
+		}
 
 		return false;
 	}
@@ -277,11 +300,15 @@ class Detect extends Render {
 	public function detect_seo_plugins() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$active_plugins = $this->active_plugins();
 
-		if ( ! $active_plugins ) return memo( false );
+		if ( ! $active_plugins ) {
+			return memo( false );
+		}
 
 		foreach ( $this->get_conflicting_plugins( 'seo_tools' ) as $plugin_name => $plugin ) {
 			if ( \in_array( $plugin, $active_plugins, true ) ) {
@@ -322,15 +349,20 @@ class Detect extends Render {
 	public function detect_og_plugin() {
 
 		// Detect SEO plugins beforehand.
-		if ( $this->detect_seo_plugins() )
+		if ( $this->detect_seo_plugins() ) {
 			return true;
+		}
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$active_plugins = $this->active_plugins();
 
-		if ( ! $active_plugins ) return memo( false );
+		if ( ! $active_plugins ) {
+			return memo( false );
+		}
 
 		foreach ( $this->get_conflicting_plugins( 'open_graph' ) as $plugin_name => $plugin ) {
 			if ( \in_array( $plugin, $active_plugins, true ) ) {
@@ -370,15 +402,20 @@ class Detect extends Render {
 	public function detect_twitter_card_plugin() {
 
 		// Detect SEO plugins beforehand.
-		if ( $this->detect_seo_plugins() )
+		if ( $this->detect_seo_plugins() ) {
 			return true;
+		}
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$active_plugins = $this->active_plugins();
 
-		if ( ! $active_plugins ) return memo( false );
+		if ( ! $active_plugins ) {
+			return memo( false );
+		}
 
 		foreach ( $this->get_conflicting_plugins( 'twitter_card' ) as $plugin_name => $plugin ) {
 			if ( \in_array( $plugin, $active_plugins, true ) ) {
@@ -434,15 +471,20 @@ class Detect extends Render {
 	public function detect_sitemap_plugin() {
 
 		// Detect SEO plugins beforehand.
-		if ( $this->detect_seo_plugins() )
+		if ( $this->detect_seo_plugins() ) {
 			return true;
+		}
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$active_plugins = $this->active_plugins();
 
-		if ( ! $active_plugins ) return memo( false );
+		if ( ! $active_plugins ) {
+			return memo( false );
+		}
 
 		foreach ( $this->get_conflicting_plugins( 'sitemaps' ) as $plugin_name => $plugin ) {
 			if ( \in_array( $plugin, $active_plugins, true ) ) {
@@ -480,10 +522,13 @@ class Detect extends Render {
 	public function use_core_sitemaps() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
-		if ( $this->get_option( 'sitemaps_output' ) )
+		if ( $this->get_option( 'sitemaps_output' ) ) {
 			return memo( false );
+		}
 
 		$wp_sitemaps_server = \wp_sitemaps_get_server();
 
@@ -535,11 +580,14 @@ class Detect extends Render {
 	 */
 	public function has_robots_txt() {
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		// Ensure get_home_path() is declared.
-		if ( ! \function_exists( '\\get_home_path' ) )
+		if ( ! \function_exists( '\\get_home_path' ) ) {
 			require_once \ABSPATH . 'wp-admin/includes/file.php';
+		}
 
 		$path = \get_home_path() . 'robots.txt';
 
@@ -558,11 +606,14 @@ class Detect extends Render {
 	 */
 	public function has_sitemap_xml() {
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		// Ensure get_home_path() is declared.
-		if ( ! \function_exists( '\\get_home_path' ) )
+		if ( ! \function_exists( '\\get_home_path' ) ) {
 			require_once \ABSPATH . 'wp-admin/includes/file.php';
+		}
 
 		$path = \get_home_path() . 'sitemap.xml';
 
@@ -584,7 +635,9 @@ class Detect extends Render {
 	public function query_supports_seo() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		switch ( true ) :
 			case \is_feed():
@@ -633,8 +686,9 @@ class Detect extends Render {
 		 * This protects against (accidental) negative-SEO bombarding.
 		 * Support broken queries, so we can noindex them.
 		 */
-		if ( ! $supported && $this->is_query_exploited() )
+		if ( ! $supported && $this->is_query_exploited() ) {
 			$supported = true;
+		}
 
 		/**
 		 * @since 4.0.0
@@ -686,20 +740,25 @@ class Detect extends Render {
 	public function is_query_exploited() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
-		if ( ! $this->get_option( 'advanced_query_protection' ) )
+		if ( ! $this->get_option( 'advanced_query_protection' ) ) {
 			return memo( false );
+		}
 
 		// When the page ID is not 0, a real page will always be returned.
-		if ( $this->get_the_real_ID() )
+		if ( $this->get_the_real_ID() ) {
 			return memo( false );
+		}
 
 		global $wp_query;
 
 		// When no special query data is registered, ignore this. Don't set cache.
-		if ( ! isset( $wp_query->query ) )
+		if ( ! isset( $wp_query->query ) ) {
 			return false;
+		}
 
 		/**
 		 * @since 4.0.5
@@ -744,34 +803,42 @@ class Detect extends Render {
 		foreach ( $exploitables as $type => $qvs ) :
 			foreach ( $qvs as $qv ) :
 				// Only test isset, because falsey or empty-array is what we need to test against.
-				if ( ! isset( $query[ $qv ] ) ) continue;
+				if ( ! isset( $query[ $qv ] ) ) {
+					continue;
+				}
 
 				switch ( $type ) :
 					case 'numeric':
-						if ( '0' === $query[ $qv ] || ! is_numeric( $query[ $qv ] ) )
+						if ( '0' === $query[ $qv ] || ! is_numeric( $query[ $qv ] ) ) {
 							return memo( true );
+						}
 						break;
 
 					case 'numeric_array':
 						// We can't protect non-pretty permalinks.
-						if ( ! $this->pretty_permalinks ) break;
+						if ( ! $this->pretty_permalinks ) {
+							break;
+						}
 
 						// If WordPress didn't canonical_redirect() the user yet, it's exploited.
 						// WordPress mitigates this via a 404 query when a numeric value is found.
-						if ( ! preg_match( '/^[1-9][0-9]*$/', $query[ $qv ] ) )
+						if ( ! preg_match( '/^[1-9][0-9]*$/', $query[ $qv ] ) ) {
 							return memo( true );
+						}
 						break;
 
 					case 'requires_s':
-						if ( ! isset( $query['s'] ) )
+						if ( ! isset( $query['s'] ) ) {
 							return memo( true );
+						}
 						break;
 
 					case 'not_home_as_page':
 						// isset($query[$qv]) is already executed. Just test if homepage ID still works.
 						// !$this->get_the_real_ID() is already executed. Just test if home is a page.
-						if ( $this->is_home_as_page() )
+						if ( $this->is_home_as_page() ) {
 							return memo( true );
+						}
 						break;
 
 					default:
@@ -798,7 +865,9 @@ class Detect extends Render {
 	public function has_posts_in_post_type_archive( $post_type ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo( null, $post_type ) ) return $memo;
+		if ( null !== $memo = memo( null, $post_type ) ) {
+			return $memo;
+		}
 
 		$query = new \WP_Query( [
 			'posts_per_page' => 1,
@@ -922,7 +991,9 @@ class Detect extends Render {
 	public function post_type_supports_taxonomies( $post_type = '' ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo( null, $post_type ) ) return $memo;
+		if ( null !== $memo = memo( null, $post_type ) ) {
+			return $memo;
+		}
 
 		$post_type = $post_type ?: $this->get_current_post_type();
 
@@ -1236,11 +1307,13 @@ class Detect extends Render {
 	 * @return bool
 	 */
 	public function is_gutenberg_page() {
-		if ( \function_exists( '\\use_block_editor_for_post' ) )
+		if ( \function_exists( '\\use_block_editor_for_post' ) ) {
 			return ! empty( $GLOBALS['post'] ) && \use_block_editor_for_post( $GLOBALS['post'] );
+		}
 
-		if ( \function_exists( '\\is_gutenberg_page' ) )
+		if ( \function_exists( '\\is_gutenberg_page' ) ) {
 			return \is_gutenberg_page();
+		}
 
 		return false;
 	}
@@ -1329,8 +1402,11 @@ class Detect extends Render {
 	 */
 	public function has_unprocessed_syntax( $text ) {
 
-		foreach ( [ 'yoast', 'rankmath', 'seopress' ] as $type )
-			if ( $this->{"has_{$type}_syntax"}( $text ) ) return true;
+		foreach ( [ 'yoast', 'rankmath', 'seopress' ] as $type ) {
+			if ( $this->{"has_{$type}_syntax"}( $text ) ) {
+				return true;
+			}
+		}
 
 		return false;
 	}
@@ -1354,8 +1430,9 @@ class Detect extends Render {
 	public function has_yoast_syntax( $text ) {
 
 		// %%id%% is the shortest valid tag... ish. Let's stop at 6.
-		if ( \strlen( $text ) < 6 || false === strpos( $text, '%%' ) )
+		if ( \strlen( $text ) < 6 || false === strpos( $text, '%%' ) ) {
 			return false;
+		}
 
 		$tags = umemo( __METHOD__ . '/tags' );
 
@@ -1441,8 +1518,9 @@ class Detect extends Render {
 	public function has_rankmath_syntax( $text ) {
 
 		// %id% is the shortest valid tag... ish. Let's stop at 4.
-		if ( \strlen( $text ) < 4 || false === strpos( $text, '%' ) )
+		if ( \strlen( $text ) < 4 || false === strpos( $text, '%' ) ) {
 			return false;
+		}
 
 		$tags = umemo( __METHOD__ . '/tags' );
 
@@ -1544,8 +1622,9 @@ class Detect extends Render {
 	public function has_seopress_syntax( $text ) {
 
 		// %%sep%% is the shortest valid tag... ish. Let's stop at 7.
-		if ( \strlen( $text ) < 7 || false === strpos( $text, '%%' ) )
+		if ( \strlen( $text ) < 7 || false === strpos( $text, '%%' ) ) {
 			return false;
+		}
 
 		$tags = umemo( __METHOD__ . '/tags' );
 

--- a/inc/classes/generate-description.class.php
+++ b/inc/classes/generate-description.class.php
@@ -464,10 +464,13 @@ class Generate_Description extends Generate {
 	 */
 	public function get_generated_description( $args = null, $escape = true, $type = 'search' ) {
 
-		if ( ! $this->is_auto_description_enabled( $args ) ) return '';
+		if ( ! $this->is_auto_description_enabled( $args ) ) {
+			return '';
+		}
 
-		if ( ! \in_array( $type, [ 'opengraph', 'twitter', 'search' ], true ) )
+		if ( ! \in_array( $type, [ 'opengraph', 'twitter', 'search' ], true ) ) {
 			$type = 'search';
+		}
 
 		if ( null === $args ) {
 			$excerpt = $this->get_description_excerpt_from_query();
@@ -566,7 +569,9 @@ class Generate_Description extends Generate {
 	protected function get_description_excerpt_from_query() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		if ( $this->is_real_front_page() ) {
 			$excerpt = $this->get_front_page_description_excerpt();
@@ -648,8 +653,9 @@ class Generate_Description extends Generate {
 	 */
 	protected function get_archival_description_excerpt( $object = null ) {
 
-		if ( $object && \is_wp_error( $object ) )
+		if ( $object && \is_wp_error( $object ) ) {
 			return '';
+		}
 
 		if ( \is_null( $object ) ) {
 			$in_the_loop = true;
@@ -672,7 +678,9 @@ class Generate_Description extends Generate {
 			]
 		);
 
-		if ( $excerpt ) return $excerpt;
+		if ( $excerpt ) {
+			return $excerpt;
+		}
 
 		if ( $in_the_loop ) {
 			if ( $this->is_category() || $this->is_tag() || $this->is_tax() ) {
@@ -733,7 +741,9 @@ class Generate_Description extends Generate {
 		$id = $id ?? $this->get_the_real_ID();
 
 		// If the post is protected, don't generate a description.
-		if ( $this->is_protected( $id ) ) return '';
+		if ( $this->is_protected( $id ) ) {
+			return '';
+		}
 
 		return $this->get_excerpt_by_id( '', $id, null, false );
 	}
@@ -785,11 +795,14 @@ class Generate_Description extends Generate {
 	 */
 	public function get_excerpt_by_id( $excerpt = '', $id = 0, $deprecated = null, $escape = true ) {
 
-		if ( empty( $excerpt ) )
+		if ( empty( $excerpt ) ) {
 			$excerpt = $this->fetch_excerpt( $id );
+		}
 
 		// No need to parse an empty excerpt.
-		if ( ! $excerpt ) return '';
+		if ( ! $excerpt ) {
+			return '';
+		}
 
 		return $escape ? $this->s_excerpt( $excerpt ) : $this->s_excerpt_raw( $excerpt );
 	}
@@ -886,7 +899,9 @@ class Generate_Description extends Generate {
 		// We'll rectify that later, somewhat, where characters are transformed.
 		// We could also use preg_match_all( '/./u' ); or count( preg_split( '/./u', $excerpt, $min_char_length ) );
 		// But, again, that'll eat CPU cycles.
-		if ( \strlen( $excerpt ) < $min_char_length ) return '';
+		if ( \strlen( $excerpt ) < $min_char_length ) {
+			return '';
+		}
 
 		// Decode to get a more accurate character length in Unicode.
 		$excerpt = html_entity_decode( $excerpt, \ENT_QUOTES, 'UTF-8' );
@@ -896,7 +911,9 @@ class Generate_Description extends Generate {
 
 		$excerpt = trim( $matches[0] ?? '' ?: '' );
 
-		if ( \strlen( $excerpt ) < $min_char_length ) return '';
+		if ( \strlen( $excerpt ) < $min_char_length ) {
+			return '';
+		}
 
 		// Texturize to recognize the sentence structure. Decode thereafter since we get HTML returned.
 		$excerpt = html_entity_decode(
@@ -949,7 +966,9 @@ class Generate_Description extends Generate {
 		}
 		// else { TODO Should we empty excerpt here? Can we even reach this? }
 
-		if ( \strlen( $excerpt ) < $min_char_length ) return '';
+		if ( \strlen( $excerpt ) < $min_char_length ) {
+			return '';
+		}
 
 		/**
 		 * @param array $matches: {
@@ -974,7 +993,9 @@ class Generate_Description extends Generate {
 			$excerpt = '';
 		}
 
-		if ( \strlen( $excerpt ) < $min_char_length ) return '';
+		if ( \strlen( $excerpt ) < $min_char_length ) {
+			return '';
+		}
 
 		return trim( htmlentities( $excerpt, \ENT_QUOTES, 'UTF-8' ) );
 	}
@@ -995,8 +1016,9 @@ class Generate_Description extends Generate {
 	 */
 	public function is_auto_description_enabled( $args = null ) {
 
-		if ( null !== $args )
+		if ( null !== $args ) {
 			$this->fix_generation_args( $args );
+		}
 
 		/**
 		 * @since 2.5.0

--- a/inc/classes/generate-image.class.php
+++ b/inc/classes/generate-image.class.php
@@ -83,8 +83,9 @@ class Generate_Image extends Generate_Url {
 		if ( $single ) {
 			$details = $this->get_custom_field_image_details( $args, $single, false );
 
-			if ( empty( $details[0]['url'] ) )
+			if ( empty( $details[0]['url'] ) ) {
 				$details = $this->get_generated_image_details( $args, $single, $context, false );
+			}
 		} else {
 			$details = array_merge(
 				$this->get_custom_field_image_details( $args, $single, false ),
@@ -483,7 +484,9 @@ class Generate_Image extends Generate_Url {
 			foreach ( \call_user_func_array( $cb, [ $args, $size ] ) as $details ) {
 				if ( $details['url'] && $this->s_url_query( $details['url'] ) ) {
 					$items[ $i ] = $this->merge_extra_image_details( $details, $size );
-					if ( $single ) break 2;
+					if ( $single ) {
+						break 2;
+					}
 					$i++;
 				}
 			}
@@ -619,8 +622,9 @@ class Generate_Image extends Generate_Url {
 		$size = '';
 
 		foreach ( $sizes as $_s => $_d ) {
-			if ( ( $_d['filesize'] ?? 0 ) > $max_filesize )
+			if ( ( $_d['filesize'] ?? 0 ) > $max_filesize ) {
 				continue;
+			}
 
 			if ( isset( $_d['width'], $_d['height'] ) ) {
 				if ( $_d['width'] <= $max_size && $_d['height'] <= $max_size && $_d['width'] > $law ) {

--- a/inc/classes/generate-ldjson.class.php
+++ b/inc/classes/generate-ldjson.class.php
@@ -127,8 +127,9 @@ class Generate_Ldjson extends Generate_Image {
 
 		static $data = [];
 
-		if ( $get )
+		if ( $get ) {
 			return $data[ $key ];
+		}
 
 		$data[ $key ][ key( $entry ) ] = reset( $entry );
 
@@ -147,8 +148,9 @@ class Generate_Ldjson extends Generate_Image {
 	public function render_ld_json_scripts() {
 
 		// Homepage Schema.org
-		if ( $this->is_real_front_page() )
+		if ( $this->is_real_front_page() ) {
 			return $this->get_ld_json_website() . $this->get_ld_json_links();
+		}
 
 		// All other pages' Schema.org
 		return $this->get_ld_json_breadcrumbs();
@@ -166,8 +168,9 @@ class Generate_Ldjson extends Generate_Image {
 	 */
 	public function get_ld_json_website() {
 
-		if ( ! $this->enable_ld_json_searchbox() )
+		if ( ! $this->enable_ld_json_searchbox() ) {
 			return '';
+		}
 
 		$data = [
 			'@context' => 'https://schema.org',
@@ -218,8 +221,9 @@ class Generate_Ldjson extends Generate_Image {
 		$this->build_json_data( $key, $data );
 		$json = $this->receive_json_data( $key );
 
-		if ( $json )
+		if ( $json ) {
 			return '<script type="application/ld+json">' . $json . '</script>' . "\n"; // Keep XHTML valid!
+		}
 
 		return '';
 	}
@@ -233,8 +237,9 @@ class Generate_Ldjson extends Generate_Image {
 	 */
 	public function get_ld_json_links() {
 
-		if ( ! $this->enable_ld_json_knowledge() )
+		if ( ! $this->enable_ld_json_knowledge() ) {
 			return '';
+		}
 
 		$knowledge_type = $this->get_option( 'knowledge_type' );
 		$knowledge_name = $this->get_option( 'knowledge_name' ) ?: $this->get_blogname();
@@ -277,8 +282,9 @@ class Generate_Ldjson extends Generate_Image {
 
 			$_ov = $this->get_option( $_o );
 
-			if ( $_ov )
+			if ( $_ov ) {
 				$sameurls[] = \esc_url_raw( $_ov, [ 'https', 'http' ] );
+			}
 		}
 
 		if ( $sameurls ) {
@@ -291,8 +297,9 @@ class Generate_Ldjson extends Generate_Image {
 		$this->build_json_data( $key, $data );
 		$json = $this->receive_json_data( $key );
 
-		if ( $json )
+		if ( $json ) {
 			return '<script type="application/ld+json">' . $json . '</script>' . "\n"; // Keep XHTML valid!
+		}
 
 		return '';
 	}
@@ -333,8 +340,9 @@ class Generate_Ldjson extends Generate_Image {
 	 */
 	public function get_ld_json_breadcrumbs() {
 
-		if ( ! $this->enable_ld_json_breadcrumbs() )
+		if ( ! $this->enable_ld_json_breadcrumbs() ) {
 			return '';
+		}
 
 		$output = '';
 
@@ -438,8 +446,9 @@ class Generate_Ldjson extends Generate_Image {
 
 		// Test categories.
 		$r = \is_object_in_term( $post_id, $taxonomy, '' );
-		if ( ! $r || \is_wp_error( $r ) )
+		if ( ! $r || \is_wp_error( $r ) ) {
 			return '';
+		}
 
 		/**
 		 * @since 2.8.0
@@ -456,8 +465,9 @@ class Generate_Ldjson extends Generate_Image {
 			]
 		);
 
-		if ( empty( $terms ) )
+		if ( empty( $terms ) ) {
 			return '';
+		}
 
 		$terms = \array_column( $terms, 'parent', 'term_id' );
 
@@ -480,19 +490,23 @@ class Generate_Ldjson extends Generate_Image {
 
 		unset( $terms );
 
-		if ( ! $parents )
+		if ( ! $parents ) {
 			return '';
+		}
 
 		// Seed out parents that have multiple assigned children.
-		foreach ( $parents as $child_id )
-			foreach ( $child_id as $cid )
+		foreach ( $parents as $child_id ) {
+			foreach ( $child_id as $cid ) {
 				unset( $parents[ $cid ] );
+			}
+		}
 
 		// Merge tree list.
 		$tree_ids = $this->build_ld_json_breadcrumb_trees( $parents );
 
-		if ( ! $tree_ids )
+		if ( ! $tree_ids ) {
 			return '';
+		}
 
 		$primary_term_id = $this->get_primary_term_id( $post_id, $taxonomy );
 
@@ -514,8 +528,9 @@ class Generate_Ldjson extends Generate_Image {
 			$tree_ids = $this->filter_ld_json_breadcrumb_trees( $tree_ids, key( $assigned_ids ) );
 		}
 
-		if ( is_scalar( $tree_ids ) )
+		if ( is_scalar( $tree_ids ) ) {
 			$tree_ids = [ $tree_ids ];
+		}
 
 		$items = [];
 
@@ -586,8 +601,9 @@ class Generate_Ldjson extends Generate_Image {
 
 					foreach ( $kitten as $child_id ) {
 						// Only add if non-existent in $trees.
-						if ( ! \in_array( $child_id, $trees, true ) )
+						if ( ! \in_array( $child_id, $trees, true ) ) {
 							$add[] = $child_id;
+						}
 					}
 
 					// Put children in right order.
@@ -650,7 +666,9 @@ class Generate_Ldjson extends Generate_Image {
 	public function get_ld_json_breadcrumb_home_crumb() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$_generator_args = [ 'id' => $this->get_the_front_page_ID() ];
 
@@ -730,8 +748,9 @@ class Generate_Ldjson extends Generate_Image {
 	 */
 	protected function make_breadcrumb_script( $items ) {
 
-		if ( ! $items )
+		if ( ! $items ) {
 			return '';
+		}
 
 		static $it = 0;
 
@@ -748,8 +767,9 @@ class Generate_Ldjson extends Generate_Image {
 
 		$it++;
 
-		if ( $json )
+		if ( $json ) {
 			return '<script type="application/ld+json">' . $json . '</script>' . "\n"; // Keep XHTML valid!
+		}
 
 		return '';
 	}

--- a/inc/classes/generate-title.class.php
+++ b/inc/classes/generate-title.class.php
@@ -80,14 +80,17 @@ class Generate_Title extends Generate_Description {
 		$title = $this->get_filtered_raw_custom_field_title( $args );
 
 		if ( $title ) {
-			if ( $this->use_title_protection( $args ) )
+			if ( $this->use_title_protection( $args ) ) {
 				$this->merge_title_protection( $title, $args );
+			}
 
-			if ( $this->use_title_pagination( $args ) )
+			if ( $this->use_title_pagination( $args ) ) {
 				$this->merge_title_pagination( $title );
+			}
 
-			if ( $this->use_title_branding( $args, $social ) )
+			if ( $this->use_title_branding( $args, $social ) ) {
 				$this->merge_title_branding( $title, $args );
+			}
 		}
 
 		return $escape ? $this->escape_title( $title ) : $title;
@@ -115,14 +118,17 @@ class Generate_Title extends Generate_Description {
 
 		$title = $this->get_filtered_raw_generated_title( $args );
 
-		if ( $this->use_title_protection( $args ) )
+		if ( $this->use_title_protection( $args ) ) {
 			$this->merge_title_protection( $title, $args );
+		}
 
-		if ( $this->use_title_pagination( $args ) )
+		if ( $this->use_title_pagination( $args ) ) {
 			$this->merge_title_pagination( $title );
+		}
 
-		if ( $this->use_title_branding( $args, $social ) )
+		if ( $this->use_title_branding( $args, $social ) ) {
 			$this->merge_title_branding( $title, $args );
+		}
 
 		$title = $this->s_title_raw( $title );
 
@@ -143,8 +149,9 @@ class Generate_Title extends Generate_Description {
 	 */
 	public function get_filtered_raw_custom_field_title( $args = null ) {
 
-		if ( null !== $args )
+		if ( null !== $args ) {
 			$this->fix_generation_args( $args );
+		}
 
 		/**
 		 * Filters the title from custom field, if any.
@@ -179,8 +186,9 @@ class Generate_Title extends Generate_Description {
 	 */
 	public function get_filtered_raw_generated_title( $args = null ) {
 
-		if ( null !== $args )
+		if ( null !== $args ) {
 			$this->fix_generation_args( $args );
+		}
 
 		/**
 		 * Filters the title from query.
@@ -593,7 +601,9 @@ class Generate_Title extends Generate_Description {
 	public function get_raw_generated_title( $args = null ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo( null, $args ) ) return $memo;
+		if ( null !== $memo = memo( null, $args ) ) {
+			return $memo;
+		}
 
 		$this->remove_default_title_filters( false, $args );
 
@@ -629,8 +639,9 @@ class Generate_Title extends Generate_Description {
 		static $filtered = [];
 
 		if ( $reset ) {
-			foreach ( $filtered as [ $filter, $function, $priority ] )
+			foreach ( $filtered as [ $filter, $function, $priority ] ) {
 				\add_filter( $filter, $function, $priority );
+			}
 
 			// Reset filters.
 			$filtered = [];
@@ -656,8 +667,9 @@ class Generate_Title extends Generate_Description {
 			 */
 			$functions = [ 'wptexturize' ];
 
-			if ( ! $this->get_option( 'title_strip_tags' ) )
+			if ( ! $this->get_option( 'title_strip_tags' ) ) {
 				$functions[] = 'strip_tags';
+			}
 
 			foreach ( $filters as $filter ) {
 				foreach ( $functions as $function ) {
@@ -669,7 +681,9 @@ class Generate_Title extends Generate_Description {
 						$filtered[] = [ $filter, $function, $priority ];
 						\remove_filter( $filter, $function, $priority );
 						// Some noob might've destroyed \WP_Hook. Safeguard.
-						if ( ++$i > $it ) break 1;
+						if ( ++$i > $it ) {
+							break 1;
+						}
 					}
 				}
 			}
@@ -778,8 +792,9 @@ class Generate_Title extends Generate_Description {
 	 */
 	public function get_generated_archive_title( $object = null ) {
 
-		if ( $object && \is_wp_error( $object ) )
+		if ( $object && \is_wp_error( $object ) ) {
 			return '';
+		}
 
 		[ $title ] = $this->get_raw_generated_archive_title_items( $object );
 
@@ -818,8 +833,9 @@ class Generate_Title extends Generate_Description {
 			'the_seo_framework_generated_archive_title_prefix and the_seo_framework_generated_archive_title'
 		);
 
-		if ( $title )
+		if ( $title ) {
 			return [ $title, '', $title ];
+		}
 
 		[ $title, $prefix ] = $object
 			? $this->get_generate_archive_title_from_term( $object )
@@ -1049,10 +1065,13 @@ class Generate_Title extends Generate_Description {
 	 */
 	public function get_generated_single_term_title( $term = null ) {
 
-		if ( \is_null( $term ) )
+		if ( \is_null( $term ) ) {
 			$term = \get_queried_object();
+		}
 
-		if ( ! isset( $term->name ) ) return '';
+		if ( ! isset( $term->name ) ) {
+			return '';
+		}
 
 		switch ( $term->taxonomy ) :
 			case 'category':
@@ -1104,16 +1123,19 @@ class Generate_Title extends Generate_Description {
 	 */
 	public function get_generated_post_type_archive_title( $post_type = '' ) {
 
-		if ( ! $post_type && ! \is_post_type_archive() )
+		if ( ! $post_type && ! \is_post_type_archive() ) {
 			return '';
+		}
 
 		$post_type = $post_type ?: $this->get_current_post_type();
 
-		if ( \is_array( $post_type ) )
+		if ( \is_array( $post_type ) ) {
 			$post_type = reset( $post_type );
+		}
 
-		if ( ! \in_array( $post_type, $this->get_public_post_type_archives(), true ) )
+		if ( ! \in_array( $post_type, $this->get_public_post_type_archives(), true ) ) {
 			return '';
+		}
 
 		/**
 		 * Filters the post type archive title.
@@ -1308,7 +1330,9 @@ class Generate_Title extends Generate_Description {
 			$merge = ! $args['taxonomy'] && ! $args['pta'];
 		}
 
-		if ( ! $merge ) return;
+		if ( ! $merge ) {
+			return;
+		}
 
 		$post = $id ? \get_post( $id ) : null;
 

--- a/inc/classes/generate-url.class.php
+++ b/inc/classes/generate-url.class.php
@@ -173,17 +173,20 @@ class Generate_Url extends Generate_Title {
 			// See and use `$this->get_canonical_url()` instead.
 			$url = $this->build_canonical_url( $args );
 
-			if ( $args['id'] === $this->get_the_real_ID() )
+			if ( $args['id'] === $this->get_the_real_ID() ) {
 				$url = $this->remove_pagination_from_url( $url );
+			}
 		} else {
 			$url = $this->generate_canonical_url();
 		}
 
-		if ( ! $url )
+		if ( ! $url ) {
 			return '';
+		}
 
-		if ( $this->matches_this_domain( $url ) )
+		if ( $this->matches_this_domain( $url ) ) {
 			$url = $this->set_preferred_url_scheme( $url );
+		}
 
 		return $this->clean_canonical_url( $url );
 	}
@@ -296,8 +299,9 @@ class Generate_Url extends Generate_Title {
 	 */
 	public function clean_canonical_url( $url ) {
 
-		if ( $this->pretty_permalinks )
+		if ( $this->pretty_permalinks ) {
 			return \esc_url( $url, [ 'https', 'http' ] );
+		}
 
 		// Keep the &'s more readable when using query-parameters.
 		return \esc_url_raw( $url, [ 'https', 'http' ] );
@@ -318,7 +322,9 @@ class Generate_Url extends Generate_Title {
 
 		$url = $this->get_raw_home_canonical_url();
 
-		if ( ! $url ) return '';
+		if ( ! $url ) {
+			return '';
+		}
 
 		$query_id = $this->get_the_real_ID();
 
@@ -376,23 +382,29 @@ class Generate_Url extends Generate_Title {
 	public function get_singular_canonical_url( $post_id = null ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = umemo( __METHOD__, null, $post_id ) ) return $memo;
+		if ( null !== $memo = umemo( __METHOD__, null, $post_id ) ) {
+			return $memo;
+		}
 
 		$url = \wp_get_canonical_url(
 			$post_id ?? $this->get_the_real_ID()
 		);
 
-		if ( ! $url ) return '';
+		if ( ! $url ) {
+			return '';
+		}
 
 		$page = \get_query_var( 'page', 1 ) ?: 1;
 		// Remove undesired/fake pagination. See: <https://core.trac.wordpress.org/ticket/37505>
-		if ( $page > 1 && $page !== $this->page() )
+		if ( $page > 1 && $page !== $this->page() ) {
 			$url = $this->remove_pagination_from_url( $url, $page, false );
+		}
 
 		// Singular archives, like blog pages and shop pages, use the pagination base with 'paged'.
 		// wp_get_canonical_url() only tests 'page'. Fix that:
-		if ( null === $post_id && $this->is_singular_archive() )
+		if ( null === $post_id && $this->is_singular_archive() ) {
 			$url = $this->add_pagination_to_url( $url, $this->paged(), true );
+		}
 
 		return umemo( __METHOD__, $url, $post_id );
 	}
@@ -439,16 +451,19 @@ class Generate_Url extends Generate_Title {
 	public function get_taxonomical_canonical_url( $term_id = null, $taxonomy = '' ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = umemo( __METHOD__, null, $term_id, $taxonomy ) )
+		if ( null !== $memo = umemo( __METHOD__, null, $term_id, $taxonomy ) ) {
 			return $memo;
+		}
 
 		$url = \get_term_link( $term_id ?: $this->get_the_real_ID(), $taxonomy );
 
-		if ( \is_wp_error( $url ) )
+		if ( \is_wp_error( $url ) ) {
 			return umemo( __METHOD__, '', $term_id, $taxonomy );
+		}
 
-		if ( null === $term_id )
+		if ( null === $term_id ) {
 			$url = $this->add_pagination_to_url( $url, $this->paged(), true );
+		}
 
 		return umemo( __METHOD__, $url, $term_id, $taxonomy );
 	}
@@ -470,7 +485,9 @@ class Generate_Url extends Generate_Title {
 
 		$url = \get_post_type_archive_link( $post_type ?? $this->get_current_post_type() );
 
-		if ( ! $url ) return '';
+		if ( ! $url ) {
+			return '';
+		}
 
 		return null === $post_type
 			? $this->add_pagination_to_url( $url, $this->paged(), true )
@@ -492,7 +509,9 @@ class Generate_Url extends Generate_Title {
 
 		$url = \get_author_posts_url( $id ?? $this->get_the_real_ID() );
 
-		if ( ! $url ) return '';
+		if ( ! $url ) {
+			return '';
+		}
 
 		return null === $id
 			? $this->add_pagination_to_url( $url, $this->paged(), true )
@@ -568,7 +587,9 @@ class Generate_Url extends Generate_Title {
 
 		$url = \get_search_link( $search_query ?? \get_search_query( false ) );
 
-		if ( ! $url ) return '';
+		if ( ! $url ) {
+			return '';
+		}
 
 		return null === $search_query
 			? $this->add_pagination_to_url( $url, $this->paged(), true )
@@ -588,7 +609,9 @@ class Generate_Url extends Generate_Title {
 	public function get_preferred_scheme() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$scheme = $this->get_option( 'canonical_scheme' );
 
@@ -675,8 +698,9 @@ class Generate_Url extends Generate_Title {
 		if ( 'relative' === $scheme ) {
 			$url = ltrim( preg_replace( '/^\w+:\/\/[^\/]*/', '', $url ) );
 
-			if ( '/' === ( $url[0] ?? '' ) )
+			if ( '/' === ( $url[0] ?? '' ) ) {
 				$url = '/' . ltrim( $url, "/ \t\n\r\0\x0B" );
+			}
 		} else {
 			$url = preg_replace( '#^\w+://#', $scheme . '://', $url );
 		}
@@ -701,8 +725,9 @@ class Generate_Url extends Generate_Title {
 
 		$page = $page ?? max( $this->paged(), $this->page() );
 
-		if ( $page < 2 )
+		if ( $page < 2 ) {
 			return $url;
+		}
 
 		$use_base = $use_base ?? (
 			$this->is_real_front_page() || $this->is_archive() || $this->is_singular_archive() || $this->is_search()
@@ -711,8 +736,9 @@ class Generate_Url extends Generate_Title {
 		if ( $this->pretty_permalinks ) {
 			$_query = parse_url( $url, \PHP_URL_QUERY );
 			// Remove queries, add them back later.
-			if ( $_query )
+			if ( $_query ) {
 				$url = $this->s_url( $url );
+			}
 
 			static $base;
 			$base = $base ?: $GLOBALS['wp_rewrite']->pagination_base;
@@ -723,8 +749,9 @@ class Generate_Url extends Generate_Title {
 				$url = \user_trailingslashit( \trailingslashit( $url ) . $page, 'single_paged' );
 			}
 
-			if ( $_query )
+			if ( $_query ) {
 				$url = $this->append_url_query( $url, $_query );
+			}
 		} else {
 			if ( $use_base ) {
 				$url = \add_query_arg( 'paged', $page, $url );
@@ -799,8 +826,9 @@ class Generate_Url extends Generate_Title {
 
 				$_query = parse_url( $url, \PHP_URL_QUERY );
 				// Remove queries, add them back later.
-				if ( $_query )
+				if ( $_query ) {
 					$url = $this->s_url( $url );
+				}
 
 				$pos = strrpos( $url, $find );
 				// Defensive programming, only remove if $find matches the stack length, without query arguments.
@@ -809,8 +837,9 @@ class Generate_Url extends Generate_Title {
 					$url = \user_trailingslashit( $url );
 
 					// Add back the query.
-					if ( $_query )
+					if ( $_query ) {
 						$url = $this->append_url_query( $url, $_query );
+					}
 				}
 			}
 		} else {
@@ -851,8 +880,12 @@ class Generate_Url extends Generate_Title {
 	 */
 	public function get_shortlink() {
 
-		if ( ! $this->get_option( 'shortlink_tag' ) ) return '';
-		if ( $this->is_real_front_page() ) return '';
+		if ( ! $this->get_option( 'shortlink_tag' ) ) {
+			return '';
+		}
+		if ( $this->is_real_front_page() ) {
+			return '';
+		}
 
 		// We slash it because plain permalinks do that too, for consistency.
 		$home = \trailingslashit( $this->get_homepage_permalink() );
@@ -885,14 +918,17 @@ class Generate_Url extends Generate_Title {
 				$tax  = $object->taxonomy ?? '';
 				$slug = $object->slug ?? '';
 
-				if ( $tax && $slug )
+				if ( $tax && $slug ) {
 					$url = \add_query_arg( [ $tax => $slug ], $home );
+				}
 			}
 		} elseif ( $this->is_search() ) {
 			$url = \add_query_arg( [ 's' => \get_search_query( false ) ], $home );
 		}
 
-		if ( ! $url ) return '';
+		if ( ! $url ) {
+			return '';
+		}
 
 		if ( $this->is_archive() || $this->is_singular_archive() || $this->is_search() ) {
 			$paged = $this->maybe_get_paged( $this->paged(), false, true );
@@ -950,11 +986,15 @@ class Generate_Url extends Generate_Title {
 	public function get_paged_urls() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$prev = $next = '';
 
-		if ( $this->has_custom_canonical_url() ) goto end;
+		if ( $this->has_custom_canonical_url() ) {
+			goto end;
+		}
 
 		if (
 			   $this->is_singular()
@@ -965,7 +1005,9 @@ class Generate_Url extends Generate_Title {
 				  ? $this->get_option( 'prev_next_frontpage' )
 				  : $this->get_option( 'prev_next_posts' );
 
-			if ( ! $_run ) goto end;
+			if ( ! $_run ) {
+				goto end;
+			}
 
 			$page      = $this->page();
 			$_numpages = $this->numpages();
@@ -979,7 +1021,9 @@ class Generate_Url extends Generate_Title {
 				  ? $this->get_option( 'prev_next_frontpage' )
 				  : $this->get_option( 'prev_next_archives' );
 
-			if ( ! $_run ) goto end;
+			if ( ! $_run ) {
+				goto end;
+			}
 
 			$page      = $this->paged();
 			$_numpages = $this->numpages();
@@ -988,7 +1032,9 @@ class Generate_Url extends Generate_Title {
 		}
 
 		// See if-statements below.
-		if ( ! ( $page + 1 <= $_numpages || $page > 1 ) ) goto end;
+		if ( ! ( $page + 1 <= $_numpages || $page > 1 ) ) {
+			goto end;
+		}
 
 		$canonical_url = memo( null, 'canonical' )
 			?? memo(
@@ -997,12 +1043,14 @@ class Generate_Url extends Generate_Title {
 			);
 
 		// If this page is not the last, create a next-URL.
-		if ( $page + 1 <= $_numpages )
+		if ( $page + 1 <= $_numpages ) {
 			$next = $this->add_pagination_to_url( $canonical_url, $page + 1 );
+		}
 
 		// If this page is not the first, create a prev-URL.
-		if ( $page > 1 )
+		if ( $page > 1 ) {
 			$prev = $this->add_pagination_to_url( $canonical_url, $page - 1 );
+		}
 
 		end:;
 
@@ -1023,7 +1071,9 @@ class Generate_Url extends Generate_Title {
 	public function get_home_host() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$parsed_url = parse_url(
 			$this->get_home_url()
@@ -1031,8 +1081,9 @@ class Generate_Url extends Generate_Title {
 
 		$host = $parsed_url['host'] ?? '';
 
-		if ( $host && isset( $parsed_url['port'] ) )
+		if ( $host && isset( $parsed_url['port'] ) ) {
 			$host .= ":{$parsed_url['port']}";
+		}
 
 		return memo( $host );
 	}
@@ -1051,11 +1102,13 @@ class Generate_Url extends Generate_Title {
 	protected function maybe_get_paged( $paged = 0, $singular = false, $plural = true ) {
 
 		if ( $paged ) {
-			if ( $singular )
+			if ( $singular ) {
 				return $paged;
+			}
 
-			if ( $plural && $paged >= 2 )
+			if ( $plural && $paged >= 2 ) {
 				return $paged;
+			}
 		}
 
 		return false;
@@ -1115,21 +1168,25 @@ class Generate_Url extends Generate_Title {
 	 */
 	public function append_url_query( $url, $query = '' ) {
 
-		if ( ! $query )
+		if ( ! $query ) {
 			return $url;
+		}
 
 		$_fragment = parse_url( $url, \PHP_URL_FRAGMENT );
 
-		if ( $_fragment )
+		if ( $_fragment ) {
 			$url = str_replace( "#$_fragment", '', $url );
+		}
 
 		parse_str( $query, $results );
 
-		if ( $results )
+		if ( $results ) {
 			$url = \add_query_arg( $results, $url );
+		}
 
-		if ( $_fragment )
+		if ( $_fragment ) {
 			$url .= "#$_fragment";
+		}
 
 		return $url;
 	}
@@ -1145,8 +1202,9 @@ class Generate_Url extends Generate_Title {
 	 */
 	public function matches_this_domain( $url ) {
 
-		if ( ! $url )
+		if ( ! $url ) {
 			return false;
+		}
 
 		$home_domain = memo() ?? memo(
 			$this->set_url_scheme( \esc_url_raw(
@@ -1156,8 +1214,9 @@ class Generate_Url extends Generate_Title {
 		);
 
 		// Test for likely match early, before transforming.
-		if ( 0 === stripos( $url, $home_domain ) )
+		if ( 0 === stripos( $url, $home_domain ) ) {
 			return true;
+		}
 
 		$url = $this->set_url_scheme( \esc_url_raw(
 			$url,

--- a/inc/classes/generate.class.php
+++ b/inc/classes/generate.class.php
@@ -50,7 +50,9 @@ class Generate extends User_Data {
 	 */
 	protected function fix_generation_args( &$args ) {
 
-		if ( null === $args ) return;
+		if ( null === $args ) {
+			return;
+		}
 
 		if ( \is_array( $args ) ) {
 			$args += [
@@ -114,13 +116,17 @@ class Generate extends User_Data {
 		foreach (
 			array_intersect_key( $meta, array_flip( [ 'noindex', 'nofollow', 'noarchive' ] ) )
 			as $k => $v
-		) $v and $meta[ $k ] = $k;
+		) {
+			$v and $meta[ $k ] = $k;
+		}
 
 		// Convert the [ 'max_snippet' => x ] to [ 'max-snippet' => 'max-snippet:x' ]
 		foreach (
 			array_intersect_key( $meta, array_flip( [ 'max_snippet', 'max_image_preview', 'max_video_preview' ] ) )
 			as $k => $v
-		) false !== $v and $meta[ $k ] = str_replace( '_', '-', $k ) . ":$v";
+		) {
+			false !== $v and $meta[ $k ] = str_replace( '_', '-', $k ) . ":$v";
+		}
 
 		/**
 		 * Filters the front-end robots array, and strips empty indexes thereafter.
@@ -282,8 +288,9 @@ class Generate extends User_Data {
 	 */
 	public function fetch_locale( $match = '' ) {
 
-		if ( ! $match )
+		if ( ! $match ) {
 			$match = \get_locale();
+		}
 
 		$match_len     = \strlen( $match );
 		$valid_locales = $this->supported_social_locales(); // [ ll_LL => ll ]
@@ -296,8 +303,9 @@ class Generate extends User_Data {
 
 		if ( 5 === $match_len ) {
 			// Full locale is used. See if it's valid and return it.
-			if ( isset( $valid_locales[ $match ] ) )
+			if ( isset( $valid_locales[ $match ] ) ) {
 				return $match;
+			}
 
 			// Convert to only language portion.
 			$match_len = 2;
@@ -308,8 +316,9 @@ class Generate extends User_Data {
 			// Only two letters of the lang are provided. Find first match and return it.
 			$key = array_search( $match, $valid_locales, true );
 
-			if ( $key )
+			if ( $key ) {
 				return $key;
+			}
 		}
 
 		// Return default WordPress locale.
@@ -375,7 +384,9 @@ class Generate extends User_Data {
 	public function get_modified_time() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$id                = $this->get_the_real_ID();
 		$post_modified_gmt = \get_post( $id )->post_modified_gmt ?? '0000-00-00 00:00:00';
@@ -414,7 +425,9 @@ class Generate extends User_Data {
 
 		$available_cards = $this->get_available_twitter_cards();
 
-		if ( ! $available_cards ) return '';
+		if ( ! $available_cards ) {
+			return '';
+		}
 
 		$option = $this->get_option( 'twitter_card' );
 

--- a/inc/classes/init.class.php
+++ b/inc/classes/init.class.php
@@ -83,11 +83,13 @@ class Init extends Query {
 	 */
 	public function init_global_actions() {
 
-		if ( \wp_doing_cron() )
+		if ( \wp_doing_cron() ) {
 			$this->init_cron_actions();
+		}
 
-		if ( \wp_doing_ajax() )
+		if ( \wp_doing_ajax() ) {
 			$this->init_ajax_actions();
+		}
 	}
 
 	/**
@@ -116,8 +118,9 @@ class Init extends Query {
 
 		// Ping searchengines.
 		if ( $this->get_option( 'ping_use_cron' ) ) {
-			if ( $this->get_option( 'sitemaps_output' ) && $this->get_option( 'ping_use_cron_prerender' ) )
+			if ( $this->get_option( 'sitemaps_output' ) && $this->get_option( 'ping_use_cron_prerender' ) ) {
 				\add_action( 'tsf_sitemap_cron_hook_before', [ new Builders\Sitemap\Base, 'prerender_sitemap' ] );
+			}
 
 			\add_action( 'tsf_sitemap_cron_hook', [ Bridges\Ping::class, 'ping_search_engines' ] );
 			\add_action( 'tsf_sitemap_cron_hook_retry', [ Bridges\Ping::class, 'retry_ping_search_engines' ] );
@@ -300,11 +303,13 @@ class Init extends Query {
 		// Output meta tags.
 		\add_action( 'wp_head', [ $this, 'html_output' ], 1 );
 
-		if ( $this->get_option( 'alter_archive_query' ) )
+		if ( $this->get_option( 'alter_archive_query' ) ) {
 			$this->init_alter_archive_query();
+		}
 
-		if ( $this->get_option( 'alter_search_query' ) )
+		if ( $this->get_option( 'alter_search_query' ) ) {
 			$this->init_alter_search_query();
+		}
 
 		// Modify the feed.
 		if ( $this->get_option( 'excerpt_the_feed' ) || $this->get_option( 'source_the_feed' ) ) {
@@ -435,8 +440,9 @@ class Init extends Query {
 		);
 
 		foreach ( $functions as $function ) {
-			if ( ! empty( $function['callback'] ) )
+			if ( ! empty( $function['callback'] ) ) {
 				echo \call_user_func_array( $function['callback'], [ ( $function['args'] ?? null ) ] );
+			}
 		}
 		// phpcs:enable, WordPress.Security.EscapeOutput
 	}
@@ -466,8 +472,9 @@ class Init extends Query {
 		);
 
 		foreach ( $functions as $function ) {
-			if ( ! empty( $function['callback'] ) )
+			if ( ! empty( $function['callback'] ) ) {
 				echo \call_user_func_array( $function['callback'], [ ( $function['args'] ?? null ) ] );
+			}
 		}
 
 		/**
@@ -500,7 +507,9 @@ class Init extends Query {
 	 */
 	public function html_output() {
 
-		if ( $this->is_preview() || \is_customize_preview() || ! $this->query_supports_seo() ) return;
+		if ( $this->is_preview() || \is_customize_preview() || ! $this->query_supports_seo() ) {
+			return;
+		}
 
 		/**
 		 * @since 2.6.0
@@ -629,7 +638,9 @@ class Init extends Query {
 		// TODO add filter to $get? It won't last a few major updates though...
 		// But that's why I created this method like so... anyway... tough luck.
 		// phpcs:ignore, WordPress.Security.EscapeOutput -- Everything we produce is escaped.
-		foreach ( $get as $method ) echo $this->{$method}();
+		foreach ( $get as $method ) {
+			echo $this->{$method}();
+		}
 
 		/**
 		 * @since 4.2.0
@@ -652,7 +663,9 @@ class Init extends Query {
 	 */
 	public function _init_custom_field_redirect() {
 
-		if ( $this->is_preview() || \is_customize_preview() || ! $this->query_supports_seo() ) return;
+		if ( $this->is_preview() || \is_customize_preview() || ! $this->query_supports_seo() ) {
+			return;
+		}
 
 		$url = $this->get_redirect_url();
 
@@ -696,8 +709,9 @@ class Init extends Query {
 		 */
 		$redirect_type = \absint( \apply_filters( 'the_seo_framework_redirect_status_code', 301 ) );
 
-		if ( $redirect_type > 399 || $redirect_type < 300 )
+		if ( $redirect_type > 399 || $redirect_type < 300 ) {
 			$this->_doing_it_wrong( __METHOD__, 'You should use 3xx HTTP Status Codes. Recommended 301 and 302.', '2.8.0' );
+		}
 
 		if ( ! $this->allow_external_redirect() ) {
 			// Only HTTP/HTTPS and home URLs are allowed.
@@ -728,7 +742,9 @@ class Init extends Query {
 	 */
 	protected function init_post_caching_actions() {
 
-		if ( has_run( __METHOD__ ) ) return;
+		if ( has_run( __METHOD__ ) ) {
+			return;
+		}
 
 		$refresh_sitemap_callback = [ Bridges\Cache::class, '_refresh_sitemap_on_post_change' ];
 
@@ -818,8 +834,9 @@ class Init extends Query {
 		 * @since 2.5.0
 		 * @param bool $disallow Whether to disallow robots queries.
 		 */
-		if ( \apply_filters( 'the_seo_framework_robots_disallow_queries', false ) )
+		if ( \apply_filters( 'the_seo_framework_robots_disallow_queries', false ) ) {
 			$output .= "Disallow: /*?*\n";
+		}
 
 		/**
 		 * @since 2.5.0
@@ -833,9 +850,11 @@ class Init extends Query {
 			if ( $this->get_option( 'sitemaps_output' ) ) {
 				$sitemaps = Bridges\Sitemap::get_instance();
 
-				foreach ( $sitemaps->get_sitemap_endpoint_list() as $id => $data )
-					if ( ! empty( $data['robots'] ) )
+				foreach ( $sitemaps->get_sitemap_endpoint_list() as $id => $data ) {
+					if ( ! empty( $data['robots'] ) ) {
 						$output .= sprintf( "\nSitemap: %s", \esc_url( $sitemaps->get_expected_sitemap_endpoint_url( $id ) ) );
+					}
+				}
 
 				$output .= "\n";
 			} elseif ( ! $this->detect_sitemap_plugin() ) { // detect_sitemap_plugin() temp backward compat.
@@ -885,8 +904,9 @@ class Init extends Query {
 		\add_action( 'the_seo_framework_sitemap_header', [ $this, '_output_robots_noindex_headers' ] );
 
 		// This is not necessarily a WordPress query. Test it inline.
-		if ( \defined( 'XMLRPC_REQUEST' ) && \XMLRPC_REQUEST )
+		if ( \defined( 'XMLRPC_REQUEST' ) && \XMLRPC_REQUEST ) {
 			$this->_output_robots_noindex_headers();
+		}
 	}
 
 	/**
@@ -905,7 +925,9 @@ class Init extends Query {
 		if ( \apply_filters(
 			'the_seo_framework_set_noindex_header',
 			\is_robots() || ( ! $this->get_option( 'index_the_feed' ) && \is_feed() )
-		) ) $this->_output_robots_noindex_headers();
+		) ) {
+			$this->_output_robots_noindex_headers();
+		}
 	}
 
 	/**
@@ -970,16 +992,19 @@ class Init extends Query {
 		// Don't exclude pages in wp-admin.
 		if ( $wp_query->is_search ) {
 			// Only interact with an actual Search Query.
-			if ( ! isset( $wp_query->query['s'] ) )
+			if ( ! isset( $wp_query->query['s'] ) ) {
 				return;
+			}
 
-			if ( $this->is_query_adjustment_blocked( $wp_query ) )
+			if ( $this->is_query_adjustment_blocked( $wp_query ) ) {
 				return;
+			}
 
 			$excluded = $this->get_excluded_ids_from_cache()['search'];
 
-			if ( ! $excluded )
+			if ( ! $excluded ) {
 				return;
+			}
 
 			$post__not_in = $wp_query->get( 'post__not_in' );
 
@@ -1007,13 +1032,15 @@ class Init extends Query {
 	public function _alter_archive_query_in( $wp_query ) {
 
 		if ( $wp_query->is_archive || $wp_query->is_home ) {
-			if ( $this->is_query_adjustment_blocked( $wp_query ) )
+			if ( $this->is_query_adjustment_blocked( $wp_query ) ) {
 				return;
+			}
 
 			$excluded = $this->get_excluded_ids_from_cache()['archive'];
 
-			if ( ! $excluded )
+			if ( ! $excluded ) {
 				return;
+			}
 
 			$post__not_in = $wp_query->get( 'post__not_in' );
 
@@ -1040,12 +1067,14 @@ class Init extends Query {
 	public function _alter_search_query_post( $posts, $wp_query ) {
 
 		if ( $wp_query->is_search ) {
-			if ( $this->is_query_adjustment_blocked( $wp_query ) )
+			if ( $this->is_query_adjustment_blocked( $wp_query ) ) {
 				return $posts;
+			}
 
 			foreach ( $posts as $n => $post ) {
-				if ( $this->get_post_meta_item( 'exclude_local_search', $post->ID ) )
+				if ( $this->get_post_meta_item( 'exclude_local_search', $post->ID ) ) {
 					unset( $posts[ $n ] );
+				}
 			}
 			// Reset numeric index.
 			$posts = array_values( $posts );
@@ -1067,12 +1096,14 @@ class Init extends Query {
 	public function _alter_archive_query_post( $posts, $wp_query ) {
 
 		if ( $wp_query->is_archive || $wp_query->is_home ) {
-			if ( $this->is_query_adjustment_blocked( $wp_query ) )
+			if ( $this->is_query_adjustment_blocked( $wp_query ) ) {
 				return $posts;
+			}
 
 			foreach ( $posts as $n => $post ) {
-				if ( $this->get_post_meta_item( 'exclude_from_archive', $post->ID ) )
+				if ( $this->get_post_meta_item( 'exclude_from_archive', $post->ID ) ) {
 					unset( $posts[ $n ] );
+				}
 			}
 			// Reset numeric index.
 			$posts = array_values( $posts );
@@ -1111,8 +1142,9 @@ class Init extends Query {
 
 		static $has_filter = null;
 
-		if ( null === $has_filter )
+		if ( null === $has_filter ) {
 			$has_filter = \has_filter( 'the_seo_framework_do_adjust_archive_query' );
+		}
 
 		if ( $has_filter ) {
 			/**
@@ -1122,12 +1154,14 @@ class Init extends Query {
 			 * @param bool      $do       True is unblocked (do adjustment), false is blocked (don't do adjustment).
 			 * @param \WP_Query $wp_query The current query.
 			 */
-			if ( ! \apply_filters_ref_array( 'the_seo_framework_do_adjust_archive_query', [ true, $wp_query ] ) )
+			if ( ! \apply_filters_ref_array( 'the_seo_framework_do_adjust_archive_query', [ true, $wp_query ] ) ) {
 				return true;
+			}
 		}
 
-		if ( ! \did_action( 'wp_loaded' ) )
+		if ( ! \did_action( 'wp_loaded' ) ) {
 			return true;
+		}
 
 		if ( \defined( 'REST_REQUEST' ) && \REST_REQUEST ) {
 			$referer = \wp_get_referer();
@@ -1140,14 +1174,16 @@ class Init extends Query {
 				 * If it returns false, the user may still be logged in, but the request isn't sent via
 				 * WordPress's API with the proper nonces supplied. This is as perfect as it can be.
 				 */
-				if ( \current_user_can( 'edit_posts' ) )
+				if ( \current_user_can( 'edit_posts' ) ) {
 					return true;
+				}
 			}
 		}
 
 		// If doing sitemap, don't adjust query via query settings.
-		if ( $this->is_sitemap() )
+		if ( $this->is_sitemap() ) {
 			return true;
+		}
 
 		// This should primarily affect 'terms'. Test if TSF is blocked from supporting said terms.
 		if ( ! empty( $wp_query->tax_query->queries ) ) :
@@ -1157,12 +1193,15 @@ class Init extends Query {
 				if ( isset( $_query['taxonomy'] ) ) {
 					$supported = $this->is_taxonomy_supported( $_query['taxonomy'] );
 					// If just one tax is supported for this query, greenlight it: all must be blocking.
-					if ( $supported ) break;
+					if ( $supported ) {
+						break;
+					}
 				}
 			}
 
-			if ( ! $supported )
+			if ( ! $supported ) {
 				return true;
+			}
 		endif;
 
 		return false;
@@ -1186,8 +1225,9 @@ class Init extends Query {
 	public function _alter_oembed_response_data( $data, $post, $width, $height ) {
 
 		// Don't use cache. See @WARNING in doc comment.
-		if ( $this->get_option( 'oembed_use_og_title', false ) )
+		if ( $this->get_option( 'oembed_use_og_title', false ) ) {
 			$data['title'] = $this->get_open_graph_title( [ 'id' => $post->ID ] ) ?: $data['title'];
+		}
 
 		// Don't use cache. See @WARNING in doc comment.
 		if ( $this->get_option( 'oembed_use_social_image', false ) ) {
@@ -1207,8 +1247,9 @@ class Init extends Query {
 		}
 
 		// Don't use cache. See @WARNING in doc comment.
-		if ( $this->get_option( 'oembed_remove_author', false ) )
+		if ( $this->get_option( 'oembed_remove_author', false ) ) {
 			unset( $data['author_url'], $data['author_name'] );
+		}
 
 		return $data;
 	}

--- a/inc/classes/internal/debug.class.php
+++ b/inc/classes/internal/debug.class.php
@@ -67,11 +67,13 @@ final class Debug {
 	 */
 	public static function _set_instance( $debug = null ) {
 
-		if ( \is_null( static::$instance ) )
+		if ( \is_null( static::$instance ) ) {
 			static::$instance = new static();
+		}
 
-		if ( isset( $debug ) )
+		if ( isset( $debug ) ) {
 			static::$instance->the_seo_framework_debug = (bool) $debug;
+		}
 	}
 
 	/**
@@ -83,8 +85,9 @@ final class Debug {
 	 */
 	public static function get_instance() {
 
-		if ( \is_null( static::$instance ) )
+		if ( \is_null( static::$instance ) ) {
 			static::_set_instance();
+		}
 
 		return static::$instance;
 	}
@@ -279,7 +282,9 @@ final class Debug {
 
 		$backtrace = debug_backtrace( \DEBUG_BACKTRACE_PROVIDE_OBJECT, 5 );
 
-		if ( ! $backtrace ) return [];
+		if ( ! $backtrace ) {
+			return [];
+		}
 
 		if ( $type & \E_USER_DEPRECATED ) {
 			/**
@@ -399,11 +404,13 @@ final class Debug {
 
 		$tsf = \tsf();
 
-		if ( \is_admin() && ! $tsf->is_term_edit() && ! $tsf->is_post_edit() && ! $tsf->is_seo_settings_page( true ) )
+		if ( \is_admin() && ! $tsf->is_term_edit() && ! $tsf->is_post_edit() && ! $tsf->is_seo_settings_page( true ) ) {
 			return;
+		}
 
-		if ( $tsf->is_seo_settings_page( true ) )
+		if ( $tsf->is_seo_settings_page( true ) ) {
 			\add_filter( 'the_seo_framework_current_object_id', [ $tsf, 'get_the_front_page_ID' ] );
+		}
 
 		// Start timer.
 		$t = microtime( true );

--- a/inc/classes/internal/deprecated.class.php
+++ b/inc/classes/internal/deprecated.class.php
@@ -299,8 +299,9 @@ final class Deprecated {
 		$tsf->_deprecated_function( 'tsf()->can_do_sitemap_robots()', '4.2.0' );
 
 		if ( $check_option ) {
-			if ( ! $tsf->get_option( 'sitemaps_output' ) || ! $tsf->get_option( 'sitemaps_robots' ) )
+			if ( ! $tsf->get_option( 'sitemaps_output' ) || ! $tsf->get_option( 'sitemaps_robots' ) ) {
 				return false;
+			}
 		}
 
 		return ! $tsf->has_robots_txt() && \strlen( $tsf->get_robots_txt_url() );
@@ -588,8 +589,9 @@ final class Deprecated {
 		$tsf = \tsf();
 		$tsf->_deprecated_function( 'tsf()->is_wc_product()', '4.2.0', 'tsf()->is_product()' );
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $tsf->is_wc_product_admin();
+		}
 
 		if ( $post ) {
 			$is_product = 'product' === \get_post_type( $post );
@@ -640,14 +642,17 @@ final class Deprecated {
 		$tsf = \tsf();
 		$tsf->_deprecated_function( 'tsf()->update_user_option()', '4.2.0', 'tsf()->update_single_user_meta_item()' );
 
-		if ( ! $option )
+		if ( ! $option ) {
 			return false;
+		}
 
-		if ( empty( $user_id ) )
+		if ( empty( $user_id ) ) {
 			$user_id = $tsf->get_user_id();
+		}
 
-		if ( empty( $user_id ) )
+		if ( empty( $user_id ) ) {
 			return false;
+		}
 
 		$meta = $tsf->get_user_meta( $user_id, false );
 
@@ -1131,8 +1136,9 @@ final class Deprecated {
 		 * Does consider 4.xx, which will become 4.xx.0.
 		 * Does not consider 4.xx-dev, which will become 4.xx-dev.0. Oh well.
 		 */
-		if ( 1 === substr_count( $wp_version, '.' ) )
+		if ( 1 === substr_count( $wp_version, '.' ) ) {
 			$wp_version .= '.0';
+		}
 
 		return (bool) version_compare( $wp_version, $version, $compare );
 	}
@@ -1189,7 +1195,9 @@ final class Deprecated {
 
 		static $detected = null;
 
-		if ( isset( $detected ) ) return $detected;
+		if ( isset( $detected ) ) {
+			return $detected;
+		}
 
 		/**
 		 * @since 4.0.6
@@ -1251,14 +1259,17 @@ final class Deprecated {
 		 */
 		$detected = \apply_filters( 'the_seo_framework_detect_page_builder', null, $post_id, $meta );
 
-		if ( \is_bool( $detected ) )
+		if ( \is_bool( $detected ) ) {
 			return $detected;
+		}
 
-		if ( ! $tsf->detect_page_builder() )
+		if ( ! $tsf->detect_page_builder() ) {
 			return false;
+		}
 
-		if ( empty( $meta ) )
+		if ( empty( $meta ) ) {
 			return false;
+		}
 
 		if ( isset( $meta['_elementor_edit_mode'][0] ) && '' !== $meta['_elementor_edit_mode'][0] && \defined( 'ELEMENTOR_VERSION' ) ) :
 			// Elementor by Elementor LTD
@@ -1338,8 +1349,9 @@ final class Deprecated {
 
 		$tzstring = \get_option( 'timezone_string' );
 
-		if ( false !== strpos( $tzstring, 'Etc/GMT' ) )
+		if ( false !== strpos( $tzstring, 'Etc/GMT' ) ) {
 			$tzstring = '';
+		}
 
 		if ( $guess && empty( $tzstring ) ) {
 			$tzstring = timezone_name_from_abbr( '', round( \get_option( 'gmt_offset' ) * \HOUR_IN_SECONDS ), 1 );
@@ -1386,8 +1398,9 @@ final class Deprecated {
 			return date_default_timezone_set( $_revert_tz );
 		}
 
-		if ( empty( $tzstring ) )
+		if ( empty( $tzstring ) ) {
 			$tzstring = $tsf->get_timezone_string( true ) ?: $old_tz;
+		}
 
 		// phpcs:ignore, WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set
 		return date_default_timezone_set( $tzstring );
@@ -1426,8 +1439,9 @@ final class Deprecated {
 
 		static $cache;
 
-		if ( isset( $cache ) )
+		if ( isset( $cache ) ) {
 			return $cache;
+		}
 
 		if ( $tsf->is_term_meta_capable() ) {
 			$cache = $tsf->get_term_meta( $tsf->get_the_real_ID() ) ?: [];
@@ -1455,8 +1469,9 @@ final class Deprecated {
 		$tsf->_deprecated_function( 'tsf()->is_blog_page()', '4.2.0', 'tsf()->is_home_as_page()' );
 
 		// When the blog page is the front page, treat it as front instead of blog.
-		if ( ! $tsf->has_page_on_front() )
+		if ( ! $tsf->has_page_on_front() ) {
 			return false;
+		}
 
 		$id = $id ?: $tsf->get_the_real_ID();
 
@@ -1485,7 +1500,9 @@ final class Deprecated {
 		\tsf()->_deprecated_function( 'tsf()->is_blog_page()', '4.2.0', 'tsf()->is_home()' );
 
 		// ID 0 cannot be a blog page.
-		if ( ! $id ) return false;
+		if ( ! $id ) {
+			return false;
+		}
 
 		return (int) \get_option( 'page_for_posts' ) === $id;
 	}
@@ -1624,10 +1641,13 @@ final class Deprecated {
 		$tsf = \tsf();
 		$tsf->_deprecated_function( 'tsf()->get_default_settings()', '4.2.0', 'tsf()->get_default_option()' );
 
-		if ( ! $key ) return false;
+		if ( ! $key ) {
+			return false;
+		}
 
-		if ( $depr )
+		if ( $depr ) {
 			$tsf->_doing_it_wrong( __METHOD__, 'The second parameter is deprecated.', '3.1.0' );
+		}
 
 		if ( ! $use_cache ) {
 			$defaults = $tsf->get_default_site_options();
@@ -1661,19 +1681,23 @@ final class Deprecated {
 		$tsf = \tsf();
 		$tsf->_deprecated_function( 'tsf()->get_warned_settings()', '4.2.0', 'tsf()->get_warned_option()' );
 
-		if ( empty( $key ) )
+		if ( empty( $key ) ) {
 			return false;
+		}
 
-		if ( $depr )
+		if ( $depr ) {
 			$tsf->_doing_it_wrong( __METHOD__, 'The second parameter is deprecated.', '3.1.0' );
+		}
 
-		if ( ! $use_cache )
+		if ( ! $use_cache ) {
 			return $tsf->s_one_zero( ! empty( $tsf->get_warned_site_options()[ $key ] ) );
+		}
 
 		static $cache;
 
-		if ( ! isset( $cache ) )
+		if ( ! isset( $cache ) ) {
 			$cache = $tsf->get_warned_site_options();
+		}
 
 		return $tsf->s_one_zero( ! empty( $cache[ $key ] ) );
 	}
@@ -1746,8 +1770,9 @@ final class Deprecated {
 	 */
 	public function get_transient( $transient ) {
 
-		if ( \The_SEO_Framework\Bridges\Cache::$use_transients )
+		if ( \The_SEO_Framework\Bridges\Cache::$use_transients ) {
 			return \get_transient( $transient );
+		}
 
 		return false;
 	}

--- a/inc/classes/interpreters/form.class.php
+++ b/inc/classes/interpreters/form.class.php
@@ -214,7 +214,9 @@ final class Form {
 	public static function get_image_uploader_form( $args ) {
 
 		// Required.
-		if ( empty( $args['id'] ) ) return '';
+		if ( empty( $args['id'] ) ) {
+			return '';
+		}
 
 		$tsf = \tsf();
 

--- a/inc/classes/interpreters/html.class.php
+++ b/inc/classes/interpreters/html.class.php
@@ -187,8 +187,9 @@ final class HTML {
 	 */
 	public static function wrap_fields( $input = '', $echo = false ) {
 
-		if ( \is_array( $input ) )
+		if ( \is_array( $input ) ) {
 			$input = implode( "\n", $input );
+		}
 
 		$output = "<div class=tsf-fields>$input</div>";
 

--- a/inc/classes/interpreters/markdown.class.php
+++ b/inc/classes/interpreters/markdown.class.php
@@ -64,8 +64,9 @@ final class Markdown {
 		$text = trim( $text );
 
 		// You need at least 3 chars to make a markdown: *m*
-		if ( \strlen( $text ) < 3 )
+		if ( \strlen( $text ) < 3 ) {
 			return '';
+		}
 
 		// Merge defaults with $args.
 		$args = array_merge( [ 'a_internal' => false ], $args );
@@ -88,8 +89,9 @@ final class Markdown {
 
 		$md_types = empty( $convert ) ? $conversions : array_intersect( $conversions, $convert );
 
-		if ( isset( $md_types['*'], $md_types['**'] ) )
+		if ( isset( $md_types['*'], $md_types['**'] ) ) {
 			$text = static::strong_em( $text );
+		}
 
 		foreach ( $md_types as $type ) :
 			switch ( $type ) :

--- a/inc/classes/interpreters/seobar.class.php
+++ b/inc/classes/interpreters/seobar.class.php
@@ -117,10 +117,13 @@ final class SEOBar {
 			'post_type' => '',
 		];
 
-		if ( ! static::$query['id'] ) return '';
+		if ( ! static::$query['id'] ) {
+			return '';
+		}
 
-		if ( ! static::$query['taxonomy'] )
+		if ( ! static::$query['taxonomy'] ) {
 			static::$query['post_type'] = static::$query['post_type'] ?: \get_post_type( static::$query['id'] );
+		}
 
 		if ( static::$query['taxonomy'] ) {
 			$builder = \The_SEO_Framework\Builders\SEOBar\Term::get_instance();
@@ -252,8 +255,9 @@ final class SEOBar {
 
 		$items = &$this->collect_seo_bar_items();
 
-		foreach ( $builder->_run_all_tests( static::$query ) as $key => $data )
+		foreach ( $builder->_run_all_tests( static::$query ) as $key => $data ) {
 			$items[ $key ] = $data;
+		}
 	}
 
 	/**
@@ -270,8 +274,9 @@ final class SEOBar {
 
 		$blocks = [];
 
-		foreach ( $this->generate_seo_bar_blocks( $items ) as $block )
+		foreach ( $this->generate_seo_bar_blocks( $items ) as $block ) {
 			$blocks[] = $block;
+		}
 
 		// Always return the wrap, may it be filled in via JS in the future.
 		return sprintf(
@@ -295,7 +300,7 @@ final class SEOBar {
 	 * @yield The SEO Bar HTML item.
 	 */
 	private function generate_seo_bar_blocks( $items ) {
-		foreach ( $items as $item )
+		foreach ( $items as $item ) {
 			yield vsprintf(
 				'<span class="tsf-seo-bar-section-wrap tsf-tooltip-wrap"><span class="tsf-seo-bar-item tsf-tooltip-item tsf-seo-bar-%1$s" title="%2$s" aria-label="%2$s" data-desc="%3$s" tabindex=0>%4$s</span></span>',
 				[
@@ -305,6 +310,7 @@ final class SEOBar {
 					\esc_html( $this->interpret_status_to_symbol( $item ) ),
 				]
 			);
+		}
 	}
 
 	/**

--- a/inc/classes/interpreters/settings-input.class.php
+++ b/inc/classes/interpreters/settings-input.class.php
@@ -53,8 +53,9 @@ final class Settings_Input {
 
 		$field_id = \THE_SEO_FRAMEWORK_SITE_OPTIONS;
 
-		foreach ( (array) $id as $subid )
+		foreach ( (array) $id as $subid ) {
 			$field_id .= "[$subid]";
+		}
 
 		return $field_id;
 	}
@@ -151,8 +152,9 @@ final class Settings_Input {
 
 		$cb_classes = [];
 
-		if ( $args['class'] )
+		if ( $args['class'] ) {
 			$cb_classes[] = $args['class'];
+		}
 
 		if ( $args['disabled'] ) {
 			$cb_classes[] = 'tsf-disabled';

--- a/inc/classes/load.class.php
+++ b/inc/classes/load.class.php
@@ -120,7 +120,9 @@ final class Load extends Site_Options {
 			[ true ],
 			'4.1.4 of The SEO Framework',
 			'constant THE_SEO_FRAMEWORK_HEADLESS'
-		) ) \defined( 'THE_SEO_FRAMEWORK_HEADLESS' ) or \define( 'THE_SEO_FRAMEWORK_HEADLESS', true );
+		) ) {
+			\defined( 'THE_SEO_FRAMEWORK_HEADLESS' ) or \define( 'THE_SEO_FRAMEWORK_HEADLESS', true );
+		}
 
 		// A headless boi is a good boi. Far less annoying, they are.
 		if ( \defined( 'THE_SEO_FRAMEWORK_HEADLESS' ) ) {
@@ -146,11 +148,13 @@ final class Load extends Site_Options {
 	public function init_debug_vars() {
 
 		$this->the_seo_framework_debug = \defined( 'THE_SEO_FRAMEWORK_DEBUG' ) && \THE_SEO_FRAMEWORK_DEBUG ?: $this->the_seo_framework_debug;
-		if ( $this->the_seo_framework_debug )
+		if ( $this->the_seo_framework_debug ) {
 			Internal\Debug::_set_instance( $this->the_seo_framework_debug );
+		}
 
-		if ( \defined( 'THE_SEO_FRAMEWORK_DISABLE_TRANSIENTS' ) && \THE_SEO_FRAMEWORK_DISABLE_TRANSIENTS )
+		if ( \defined( 'THE_SEO_FRAMEWORK_DISABLE_TRANSIENTS' ) && \THE_SEO_FRAMEWORK_DISABLE_TRANSIENTS ) {
 			\The_SEO_Framework\Bridges\Cache::$use_transients = false;
+		}
 
 		// WP Core definition.
 		$this->script_debug = \defined( 'SCRIPT_DEBUG' ) && \SCRIPT_DEBUG ?: $this->script_debug;

--- a/inc/classes/post-data.class.php
+++ b/inc/classes/post-data.class.php
@@ -90,7 +90,9 @@ class Post_Data extends Detect {
 	public function get_post_meta( $post_id, $use_cache = true ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( $use_cache && ( $memo = umemo( __METHOD__, null, $post_id ) ) ) return $memo;
+		if ( $use_cache && ( $memo = umemo( __METHOD__, null, $post_id ) ) ) {
+			return $memo;
+		}
 
 		// get_post_meta() requires a valid post ID. Make sure that post exists.
 		$post = \get_post( $post_id );
@@ -121,8 +123,9 @@ class Post_Data extends Detect {
 			);
 
 			// WP converts all entries to arrays, because we got ALL entries. Disarray!
-			foreach ( $meta as &$value )
+			foreach ( $meta as &$value ) {
 				$value = $value[0];
+			}
 		}
 
 		/**
@@ -225,7 +228,9 @@ class Post_Data extends Detect {
 
 		$post = \get_post( $post );
 
-		if ( ! $post ) return;
+		if ( ! $post ) {
+			return;
+		}
 
 		$meta          = $this->get_post_meta( $post->ID, false );
 		$meta[ $item ] = $value;
@@ -246,7 +251,9 @@ class Post_Data extends Detect {
 
 		$post = \get_post( $post );
 
-		if ( ! $post ) return;
+		if ( ! $post ) {
+			return;
+		}
 
 		$data = (array) \wp_parse_args( $data, $this->get_post_meta_defaults( $post->ID ) );
 
@@ -336,7 +343,9 @@ class Post_Data extends Detect {
 
 		$post = \get_post( $post );
 
-		if ( ! $post ) return;
+		if ( ! $post ) {
+			return;
+		}
 
 		/**
 		 * Don't try to save the data prior autosave, or revision post (is_preview).
@@ -345,7 +354,9 @@ class Post_Data extends Detect {
 		 * @link https://github.com/sybrew/the-seo-framework/issues/48
 		 * @link https://johnblackbourn.com/post-meta-revisions-wordpress
 		 */
-		if ( \wp_is_post_autosave( $post ) || \wp_is_post_revision( $post ) ) return;
+		if ( \wp_is_post_autosave( $post ) || \wp_is_post_revision( $post ) ) {
+			return;
+		}
 
 		$nonce_name   = $this->inpost_nonce_name;
 		$nonce_action = $this->inpost_nonce_field;
@@ -355,7 +366,9 @@ class Post_Data extends Detect {
 			   ! \current_user_can( 'edit_post', $post->ID )
 			|| ! isset( $_POST[ $nonce_name ] )
 			|| ! \wp_verify_nonce( $_POST[ $nonce_name ], $nonce_action )
-		) return;
+		) {
+			return;
+		}
 
 		$data = (array) $_POST['autodescription'];
 
@@ -377,14 +390,18 @@ class Post_Data extends Detect {
 
 		$post = \get_post( $post );
 
-		if ( empty( $post->ID ) ) return;
+		if ( empty( $post->ID ) ) {
+			return;
+		}
 
 		// Check again against ambiguous injection...
 		// Note, however: function wp_ajax_inline_save() already performs all these checks for us before firing this callback's action.
 		if (
 			   ! \current_user_can( 'edit_post', $post->ID )
 			|| ! \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false )
-		) return;
+		) {
+			return;
+		}
 
 		$new_data = [];
 
@@ -437,11 +454,15 @@ class Post_Data extends Detect {
 
 		$post = \get_post( $post );
 
-		if ( ! $post ) return;
+		if ( ! $post ) {
+			return;
+		}
 
 		// Check again against ambiguous injection...
 		// Note, however: function bulk_edit_posts() already performs all these checks for us before firing this callback's action.
-		if ( ! \current_user_can( 'edit_post', $post->ID ) ) return;
+		if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
+			return;
+		}
 
 		static $verified_referer = false;
 		// Memoize the referer check--if it passes (and doesn't exit/die PHP), we're good to execute subsequently.
@@ -461,7 +482,9 @@ class Post_Data extends Detect {
 					case 'noindex':
 					case 'nofollow':
 					case 'noarchive':
-						if ( 'nochange' === $value ) continue 2;
+						if ( 'nochange' === $value ) {
+							continue 2;
+						}
 						$new_data[ "_genesis_$key" ] = $value;
 						break;
 
@@ -497,11 +520,15 @@ class Post_Data extends Detect {
 
 		// The 'autodescription' index should only be used when using the editor.
 		// Quick and bulk-edit should be halted here.
-		if ( empty( $_POST['autodescription'] ) ) return;
+		if ( empty( $_POST['autodescription'] ) ) {
+			return;
+		}
 
 		$post = \get_post( $post );
 
-		if ( ! $post ) return;
+		if ( ! $post ) {
+			return;
+		}
 
 		/**
 		 * Don't try to save the data prior autosave, or revision post (is_preview).
@@ -510,14 +537,20 @@ class Post_Data extends Detect {
 		 * @link https://github.com/sybrew/the-seo-framework/issues/48
 		 * @link https://johnblackbourn.com/post-meta-revisions-wordpress
 		 */
-		if ( \wp_is_post_autosave( $post ) || \wp_is_post_revision( $post ) ) return;
+		if ( \wp_is_post_autosave( $post ) || \wp_is_post_revision( $post ) ) {
+			return;
+		}
 
 		// Check that the user is allowed to edit the post. Nonce checks are done in bulk later.
-		if ( ! \current_user_can( 'edit_post', $post->ID ) ) return;
+		if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
+			return;
+		}
 
 		$post_type = \get_post_type( $post ) ?: false;
 		// Can this even fail?
-		if ( ! $post_type ) return;
+		if ( ! $post_type ) {
+			return;
+		}
 
 		foreach ( $this->get_hierarchical_taxonomies_as( 'names', $post_type ) as $_taxonomy ) {
 			$_post_key = "_primary_term_{$_taxonomy}";
@@ -551,7 +584,9 @@ class Post_Data extends Detect {
 	public function get_latest_post_id() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$query = new \WP_Query( [
 			'posts_per_page'   => 1,
@@ -613,12 +648,14 @@ class Post_Data extends Detect {
 		 */
 		$detected = \apply_filters( 'the_seo_framework_detect_non_html_page_builder', null, $post_id, $meta );
 
-		if ( \is_bool( $detected ) )
+		if ( \is_bool( $detected ) ) {
 			return $detected;
+		}
 
 		// If there's no meta, or no builder active, it doesn't use a builder.
-		if ( empty( $meta ) || ! $this->detect_non_html_page_builder() )
+		if ( empty( $meta ) || ! $this->detect_non_html_page_builder() ) {
 			return false;
+		}
 
 		if ( 'on' === ( $meta['_et_pb_use_builder'][0] ?? '' ) && \defined( 'ET_BUILDER_VERSION' ) ) :
 			// Divi Builder by Elegant Themes
@@ -713,15 +750,18 @@ class Post_Data extends Detect {
 	 */
 	public function get_excluded_ids_from_cache() {
 
-		if ( $this->is_headless['meta'] )
+		if ( $this->is_headless['meta'] ) {
 			return [
 				'archive' => '',
 				'search'  => '',
 			];
+		}
 
 		$cache = $this->get_static_cache( 'excluded_ids' );
 
-		if ( isset( $cache['archive'], $cache['search'] ) ) return $cache;
+		if ( isset( $cache['archive'], $cache['search'] ) ) {
+			return $cache;
+		}
 
 		global $wpdb;
 
@@ -804,11 +844,15 @@ class Post_Data extends Detect {
 	public function get_primary_term( $post_id, $taxonomy ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo( null, $post_id, $taxonomy ) ) return $memo;
+		if ( null !== $memo = memo( null, $post_id, $taxonomy ) ) {
+			return $memo;
+		}
 
 		$primary_id = (int) \get_post_meta( $post_id, "_primary_term_{$taxonomy}", true ) ?: 0;
 
-		if ( ! $primary_id ) return memo( false, $post_id, $taxonomy );
+		if ( ! $primary_id ) {
+			return memo( false, $post_id, $taxonomy );
+		}
 
 		// Users can alter the term list via quick/bulk edit, but cannot set a primary term that way.
 		// Users can also delete a term from the site that was previously assigned as primary.
@@ -819,10 +863,12 @@ class Post_Data extends Detect {
 		$primary_term = false;
 
 		// Test for is_array in the unlikely event a post's taxonomy is gone ($terms = WP_Error)
-		if ( \is_array( $terms ) ) foreach ( $terms as $term ) {
-			if ( $primary_id === (int) $term->term_id ) {
-				$primary_term = $term;
-				break;
+		if ( \is_array( $terms ) ) {
+			foreach ( $terms as $term ) {
+				if ( $primary_id === (int) $term->term_id ) {
+					$primary_term = $term;
+					break;
+				}
 			}
 		}
 

--- a/inc/classes/query.class.php
+++ b/inc/classes/query.class.php
@@ -64,13 +64,17 @@ class Query extends Core {
 		// Don't use method memo() here for this method is called over 85 times per page.
 		static $memo;
 
-		if ( isset( $memo ) ) return $memo;
+		if ( isset( $memo ) ) {
+			return $memo;
+		}
 
-		if ( \defined( 'WP_CLI' ) && \WP_CLI )
+		if ( \defined( 'WP_CLI' ) && \WP_CLI ) {
 			return $memo = false;
+		}
 
-		if ( isset( $GLOBALS['wp_query']->query ) || isset( $GLOBALS['current_screen'] ) )
+		if ( isset( $GLOBALS['wp_query']->query ) || isset( $GLOBALS['current_screen'] ) ) {
 			return $memo = true;
+		}
 
 		$this->the_seo_framework_debug
 			and $this->do_query_error_notice( $method );
@@ -119,8 +123,9 @@ class Query extends Core {
 	 */
 	public function get_post_type_real_ID( $post = null ) {
 
-		if ( isset( $post ) )
+		if ( isset( $post ) ) {
 			return \get_post_type( $post );
+		}
 
 		if ( $this->is_archive() ) {
 			if ( $this->is_category() || $this->is_tag() || $this->is_tax() ) {
@@ -180,11 +185,14 @@ class Query extends Core {
 	 */
 	public function get_the_real_ID( $use_cache = true ) { // phpcs:ignore -- ID is capitalized because WordPress does that too: get_the_ID().
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->get_the_real_admin_ID();
+		}
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( $use_cache && null !== $memo = umemo( __METHOD__ ) ) return $memo;
+		if ( $use_cache && null !== $memo = umemo( __METHOD__ ) ) {
+			return $memo;
+		}
 
 		$use_cache = $use_cache && $this->can_cache_query( __METHOD__ );
 
@@ -232,8 +240,9 @@ class Query extends Core {
 		$id = \get_the_ID();
 
 		// Current term ID (outside loop).
-		if ( ! $id && $this->is_archive_admin() )
+		if ( ! $id && $this->is_archive_admin() ) {
 			$id = $this->get_admin_term_id();
+		}
 
 		return (int) \apply_filters( 'the_seo_framework_current_admin_id', $id );
 	}
@@ -268,8 +277,9 @@ class Query extends Core {
 	 */
 	public function get_admin_term_id() {
 
-		if ( false === $this->is_archive_admin() )
+		if ( false === $this->is_archive_admin() ) {
 			return 0;
+		}
 
 		return \absint(
 			! empty( $GLOBALS['tag_ID'] ) ? $GLOBALS['tag_ID'] : 0
@@ -343,11 +353,13 @@ class Query extends Core {
 	 */
 	public function is_attachment( $attachment = '' ) {
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_attachment_admin();
+		}
 
-		if ( ! $attachment )
+		if ( ! $attachment ) {
 			return \is_attachment();
+		}
 
 		return $this->memo_query( null, $attachment )
 			?? $this->memo_query( \is_attachment( $attachment ), $attachment );
@@ -418,23 +430,28 @@ class Query extends Core {
 	 */
 	public function is_archive() {
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_archive_admin();
+		}
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = $this->memo_query() ) return $memo;
+		if ( null !== $memo = $this->memo_query() ) {
+			return $memo;
+		}
 
 		$can_cache = $this->can_cache_query( __METHOD__ );
 
-		if ( \is_archive() && false === $this->is_singular() )
+		if ( \is_archive() && false === $this->is_singular() ) {
 			return $can_cache ? $this->memo_query( true ) : true;
+		}
 
 		// The $can_cache check is used here because it asserted $wp_query is valid on the front-end.
 		if ( $can_cache && false === $this->is_singular() ) {
 			global $wp_query;
 
-			if ( $wp_query->is_category || $wp_query->is_tag || $wp_query->is_tax || $wp_query->is_post_type_archive || $wp_query->is_date || $wp_query->is_author )
+			if ( $wp_query->is_category || $wp_query->is_tag || $wp_query->is_tax || $wp_query->is_post_type_archive || $wp_query->is_date || $wp_query->is_author ) {
 				return $this->memo_query( true );
+			}
 		}
 
 		return $can_cache ? $this->memo_query( false ) : false;
@@ -532,8 +549,9 @@ class Query extends Core {
 	 */
 	public function is_author( $author = '' ) {
 
-		if ( ! $author )
+		if ( ! $author ) {
 			return \is_author();
+		}
 
 		return $this->memo_query( null, $author )
 			?? $this->memo_query( \is_author( $author ), $author );
@@ -587,8 +605,9 @@ class Query extends Core {
 	 */
 	public function is_category( $category = '' ) {
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_category_admin();
+		}
 
 		return $this->memo_query( null, $category )
 			?? $this->memo_query( \is_category( $category ), $category );
@@ -673,8 +692,9 @@ class Query extends Core {
 	public function is_real_front_page() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition
-		if ( null !== $cache = $this->memo_query() )
+		if ( null !== $cache = $this->memo_query() ) {
 			return $cache;
+		}
 
 		$is_front_page = \is_front_page();
 
@@ -733,11 +753,13 @@ class Query extends Core {
 	 */
 	public function is_page( $page = '' ) {
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_page_admin();
+		}
 
-		if ( empty( $page ) )
+		if ( empty( $page ) ) {
 			return \is_page();
+		}
 
 		return $this->memo_query( null, $page )
 			?? $this->memo_query(
@@ -815,8 +837,9 @@ class Query extends Core {
 	 */
 	public function is_single( $post = '' ) {
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_single_admin();
+		}
 
 		return $this->memo_query( null, $post )
 			?? $this->memo_query(
@@ -857,11 +880,13 @@ class Query extends Core {
 	public function is_singular( $post_types = '' ) {
 
 		// WP_Query functions require loop, do alternative check.
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_singular_admin();
+		}
 
-		if ( $post_types )
+		if ( $post_types ) {
 			return \is_singular( $post_types );
+		}
 
 		return $this->memo_query()
 			?? $this->memo_query( \is_singular() || $this->is_singular_archive() );
@@ -921,8 +946,9 @@ class Query extends Core {
 	public function is_tag( $tag = '' ) {
 
 		// Admin requires another check.
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_tag_admin();
+		}
 
 		return $this->memo_query( null, $tag )
 			?? $this->memo_query( \is_tag( $tag ), $tag );
@@ -990,8 +1016,9 @@ class Query extends Core {
 	 */
 	public function is_product( $post = null ) {
 
-		if ( \is_admin() )
+		if ( \is_admin() ) {
 			return $this->is_product_admin();
+		}
 
 		return $this->memo_query( null, $post )
 			?? $this->memo_query(
@@ -1066,11 +1093,13 @@ class Query extends Core {
 	 */
 	public function is_seo_settings_page( $secure = true ) {
 
-		if ( ! \is_admin() )
+		if ( ! \is_admin() ) {
 			return false;
+		}
 
-		if ( ! $secure )
+		if ( ! $secure ) {
 			return $this->is_menu_page( $this->seo_settings_page_hook, $this->seo_settings_page_slug );
+		}
 
 		return $this->memo_query()
 			?? $this->memo_query( $this->is_menu_page( $this->seo_settings_page_hook ) );
@@ -1127,8 +1156,9 @@ class Query extends Core {
 	public function page() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition
-		if ( null !== $memo = $this->memo_query() )
+		if ( null !== $memo = $this->memo_query() ) {
 			return $memo;
+		}
 
 		if ( $this->is_multipage() ) {
 			$page = ( (int) \get_query_var( 'page' ) ) ?: 1;
@@ -1163,8 +1193,9 @@ class Query extends Core {
 	public function paged() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition
-		if ( null !== $memo = $this->memo_query() )
+		if ( null !== $memo = $this->memo_query() ) {
 			return $memo;
+		}
 
 		if ( $this->is_multipage() ) {
 			$paged = ( (int) \get_query_var( 'paged' ) ) ?: 1;
@@ -1196,8 +1227,9 @@ class Query extends Core {
 	public function numpages() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition
-		if ( null !== $memo = $this->memo_query() )
+		if ( null !== $memo = $this->memo_query() ) {
 			return $memo;
+		}
 
 		if ( \is_admin() ) {
 			// Disable pagination detection in admin: Always on page 1.
@@ -1206,8 +1238,9 @@ class Query extends Core {
 
 		global $wp_query;
 
-		if ( $this->is_singular() && ! $this->is_singular_archive() )
+		if ( $this->is_singular() && ! $this->is_singular_archive() ) {
 			$post = \get_post( $this->get_the_real_ID() );
+		}
 
 		if ( ( $post ?? null ) instanceof \WP_Post ) {
 			$content = $this->get_post_content( $post );
@@ -1216,8 +1249,9 @@ class Query extends Core {
 				$content = str_replace( "\n<!--nextpage-->", '<!--nextpage-->', $content );
 
 				// Ignore nextpage at the beginning of the content.
-				if ( 0 === strpos( $content, '<!--nextpage-->' ) )
+				if ( 0 === strpos( $content, '<!--nextpage-->' ) ) {
 					$content = substr( $content, 15 );
+				}
 
 				$pages = explode( '<!--nextpage-->', $content );
 			} else {

--- a/inc/classes/render.class.php
+++ b/inc/classes/render.class.php
@@ -48,8 +48,9 @@ class Render extends Admin_Init {
 	 */
 	public function get_document_title( $title = '' ) {
 
-		if ( ! $this->query_supports_seo() )
+		if ( ! $this->query_supports_seo() ) {
 			return $title;
+		}
 
 		/**
 		 * @since 3.1.0
@@ -80,8 +81,9 @@ class Render extends Admin_Init {
 	 */
 	public function get_wp_title( $title = '' ) {
 
-		if ( ! $this->query_supports_seo() )
+		if ( ! $this->query_supports_seo() ) {
 			return $title;
+		}
 
 		/**
 		 * @since 3.1.0
@@ -114,7 +116,9 @@ class Render extends Admin_Init {
 
 		foreach ( $this->get_image_details_from_cache( ! $this->get_option( 'multi_og_image' ) ) as $image ) {
 			$url = $image['url'];
-			if ( $url ) break;
+			if ( $url ) {
+				break;
+			}
 		}
 
 		return $url ?? '';
@@ -279,8 +283,9 @@ class Render extends Admin_Init {
 	 */
 	public function og_description() {
 
-		if ( ! $this->use_og_tags() )
+		if ( ! $this->use_og_tags() ) {
 			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -311,8 +316,9 @@ class Render extends Admin_Init {
 	 */
 	public function og_locale() {
 
-		if ( ! $this->use_og_tags() )
+		if ( ! $this->use_og_tags() ) {
 			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -345,8 +351,9 @@ class Render extends Admin_Init {
 	 */
 	public function og_title() {
 
-		if ( ! $this->use_og_tags() )
+		if ( ! $this->use_og_tags() ) {
 			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -377,8 +384,9 @@ class Render extends Admin_Init {
 	 */
 	public function og_type() {
 
-		if ( ! $this->use_og_tags() )
+		if ( ! $this->use_og_tags() ) {
 			return '';
+		}
 
 		$type = $this->get_og_type();
 
@@ -401,7 +409,9 @@ class Render extends Admin_Init {
 	 */
 	public function og_image() {
 
-		if ( ! $this->use_og_tags() ) return '';
+		if ( ! $this->use_og_tags() ) {
+			return '';
+		}
 
 		$output = '';
 
@@ -432,7 +442,9 @@ class Render extends Admin_Init {
 			}
 
 			// Redundant?
-			if ( ! $multi ) break;
+			if ( ! $multi ) {
+				break;
+			}
 		}
 
 		return $output;
@@ -448,7 +460,9 @@ class Render extends Admin_Init {
 	 */
 	public function og_sitename() {
 
-		if ( ! $this->use_og_tags() ) return '';
+		if ( ! $this->use_og_tags() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -482,7 +496,9 @@ class Render extends Admin_Init {
 	 */
 	public function og_url() {
 
-		if ( ! $this->use_og_tags() ) return '';
+		if ( ! $this->use_og_tags() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.9.3
@@ -512,7 +528,9 @@ class Render extends Admin_Init {
 	 */
 	public function twitter_card() {
 
-		if ( ! $this->use_twitter_tags() ) return '';
+		if ( ! $this->use_twitter_tags() ) {
+			return '';
+		}
 
 		$card = $this->get_current_twitter_card_type();
 
@@ -531,7 +549,9 @@ class Render extends Admin_Init {
 	 */
 	public function twitter_site() {
 
-		if ( ! $this->use_twitter_tags() ) return '';
+		if ( ! $this->use_twitter_tags() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -565,7 +585,9 @@ class Render extends Admin_Init {
 	 */
 	public function twitter_creator() {
 
-		if ( ! $this->use_twitter_tags() ) return '';
+		if ( ! $this->use_twitter_tags() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -598,7 +620,9 @@ class Render extends Admin_Init {
 	 */
 	public function twitter_title() {
 
-		if ( ! $this->use_twitter_tags() ) return '';
+		if ( ! $this->use_twitter_tags() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -631,7 +655,9 @@ class Render extends Admin_Init {
 	 */
 	public function twitter_description() {
 
-		if ( ! $this->use_twitter_tags() ) return '';
+		if ( ! $this->use_twitter_tags() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -666,7 +692,9 @@ class Render extends Admin_Init {
 	 */
 	public function twitter_image() {
 
-		if ( ! $this->use_twitter_tags() ) return '';
+		if ( ! $this->use_twitter_tags() ) {
+			return '';
+		}
 
 		$output = '';
 
@@ -718,8 +746,12 @@ class Render extends Admin_Init {
 	 */
 	public function facebook_author() {
 
-		if ( ! $this->use_facebook_tags() ) return '';
-		if ( 'article' !== $this->get_og_type() ) return '';
+		if ( ! $this->use_facebook_tags() ) {
+			return '';
+		}
+		if ( 'article' !== $this->get_og_type() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -751,8 +783,12 @@ class Render extends Admin_Init {
 	 */
 	public function facebook_publisher() {
 
-		if ( ! $this->use_facebook_tags() ) return '';
-		if ( 'article' !== $this->get_og_type() ) return '';
+		if ( ! $this->use_facebook_tags() ) {
+			return '';
+		}
+		if ( 'article' !== $this->get_og_type() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -783,7 +819,9 @@ class Render extends Admin_Init {
 	 */
 	public function facebook_app_id() {
 
-		if ( ! $this->use_facebook_tags() ) return '';
+		if ( ! $this->use_facebook_tags() ) {
+			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -818,13 +856,16 @@ class Render extends Admin_Init {
 	 */
 	public function article_published_time() {
 
-		if ( ! $this->output_published_time() ) return '';
+		if ( ! $this->output_published_time() ) {
+			return '';
+		}
 
 		$id            = $this->get_the_real_ID();
 		$post_date_gmt = \get_post( $id )->post_date_gmt ?? '0000-00-00 00:00:00';
 
-		if ( '0000-00-00 00:00:00' === $post_date_gmt )
+		if ( '0000-00-00 00:00:00' === $post_date_gmt ) {
 			return '';
+		}
 
 		/**
 		 * @since 2.3.0
@@ -861,7 +902,9 @@ class Render extends Admin_Init {
 	 */
 	public function article_modified_time() {
 
-		if ( ! $this->output_modified_time() ) return '';
+		if ( ! $this->output_modified_time() ) {
+			return '';
+		}
 
 		$time = $this->get_modified_time();
 
@@ -880,8 +923,12 @@ class Render extends Admin_Init {
 	 */
 	public function og_updated_time() {
 
-		if ( ! $this->use_og_tags() ) return '';
-		if ( ! $this->output_published_time() ) return '';
+		if ( ! $this->use_og_tags() ) {
+			return '';
+		}
+		if ( ! $this->output_published_time() ) {
+			return '';
+		}
 
 		$time = $this->get_modified_time();
 
@@ -1109,7 +1156,9 @@ class Render extends Admin_Init {
 	public function robots() {
 
 		// Don't do anything if the blog isn't set to public.
-		if ( false === $this->is_blog_public() ) return '';
+		if ( false === $this->is_blog_public() ) {
+			return '';
+		}
 
 		$meta = $this->get_robots_meta();
 
@@ -1278,7 +1327,9 @@ class Render extends Admin_Init {
 			) ) ),
 		] );
 
-		if ( ! $cache['run'] ) return '';
+		if ( ! $cache['run'] ) {
+			return '';
+		}
 
 		switch ( $where ) :
 			case 'before':
@@ -1310,8 +1361,9 @@ class Render extends Admin_Init {
 	 */
 	public function output_modified_time() {
 
-		if ( 'article' !== $this->get_og_type() )
+		if ( 'article' !== $this->get_og_type() ) {
 			return false;
+		}
 
 		return (bool) $this->get_option( 'post_modify_time' );
 	}
@@ -1326,8 +1378,9 @@ class Render extends Admin_Init {
 	 */
 	public function output_published_time() {
 
-		if ( 'article' !== $this->get_og_type() )
+		if ( 'article' !== $this->get_og_type() ) {
 			return false;
+		}
 
 		return (bool) $this->get_option( 'post_publish_time' );
 	}

--- a/inc/classes/sanitize.class.php
+++ b/inc/classes/sanitize.class.php
@@ -52,7 +52,9 @@ class Sanitize extends Admin_Pages {
 	protected function verify_seo_settings_nonce() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		/**
 		 * If this page doesn't parse the site options,
@@ -64,11 +66,14 @@ class Sanitize extends Admin_Pages {
 		if (
 			   empty( $_POST[ \THE_SEO_FRAMEWORK_SITE_OPTIONS ] )
 			|| ! \is_array( $_POST[ \THE_SEO_FRAMEWORK_SITE_OPTIONS ] )
-		) return memo( false );
+		) {
+			return memo( false );
+		}
 
 		// This is also handled in /wp-admin/options.php. Nevertheless, one might register outside of scope.
-		if ( ! \current_user_can( $this->get_settings_capability() ) )
+		if ( ! \current_user_can( $this->get_settings_capability() ) ) {
 			return memo( false );
+		}
 
 		// This is also handled in /wp-admin/options.php. Nevertheless, one might register outside of scope.
 		// This also checks the nonce: `_wpnonce`.
@@ -91,7 +96,9 @@ class Sanitize extends Admin_Pages {
 	protected function process_settings_submission() {
 
 		// Verify update headers.
-		if ( ! $this->verify_seo_settings_nonce() ) return;
+		if ( ! $this->verify_seo_settings_nonce() ) {
+			return;
+		}
 
 		// Initialize sanitation filters parsed on each option update.
 		$this->init_sanitizer_filters();
@@ -172,7 +179,9 @@ class Sanitize extends Admin_Pages {
 	 */
 	public function init_sanitizer_filters() {
 
-		if ( has_run( __METHOD__ ) ) return;
+		if ( has_run( __METHOD__ ) ) {
+			return;
+		}
 
 		$this->add_option_filter(
 			's_title_separator',
@@ -572,8 +581,9 @@ class Sanitize extends Admin_Pages {
 
 		static $options = [];
 
-		if ( $get )
+		if ( $get ) {
 			return $options;
+		}
 
 		if ( \is_array( $suboption ) ) {
 			foreach ( $suboption as $so ) {
@@ -650,8 +660,9 @@ class Sanitize extends Admin_Pages {
 
 		$available_filters = $this->get_available_filters();
 
-		if ( ! \in_array( $filter, array_keys( $available_filters ), true ) )
+		if ( ! \in_array( $filter, array_keys( $available_filters ), true ) ) {
 			return $new_value;
+		}
 
 		return \call_user_func_array(
 			$available_filters[ $filter ],
@@ -732,13 +743,15 @@ class Sanitize extends Admin_Pages {
 	 */
 	public function s_all_post_type_archive_meta( $data ) {
 
-		if ( ! $data )
+		if ( ! $data ) {
 			return [];
+		}
 
 		// Do NOT test for post type's existence -- it might be registered incorrectly.
 		// If the metadata yields empty -- do not unset key! It'll override "defaults" that way.
-		foreach ( $data as &$meta )
+		foreach ( $data as &$meta ) {
 			$meta = $this->s_post_type_archive_meta( $meta );
+		}
 
 		return $data;
 	}
@@ -896,8 +909,9 @@ class Sanitize extends Admin_Pages {
 				case 'counter_type':
 					$value = \absint( $value );
 
-					if ( $value > 3 )
+					if ( $value > 3 ) {
 						$value = 0;
+					}
 					continue 2;
 
 				default:
@@ -923,14 +937,16 @@ class Sanitize extends Admin_Pages {
 
 		$key = \array_key_exists( $new_value, $title_separator );
 
-		if ( $key )
+		if ( $key ) {
 			return (string) $new_value;
+		}
 
 		$previous = $this->get_option( 'title_separator' );
 
 		// Fallback to default if empty.
-		if ( empty( $previous ) )
+		if ( empty( $previous ) ) {
 			$previous = $this->get_default_option( 'title_separator' );
+		}
 
 		return (string) $previous;
 	}
@@ -1075,7 +1091,9 @@ class Sanitize extends Admin_Pages {
 	public function s_excerpt( $excerpt = '', $allow_shortcodes = true, $escape = true ) {
 
 		// No need to parse an empty excerpt. TODO consider not parsing '0' as well?
-		if ( '' === $excerpt ) return '';
+		if ( '' === $excerpt ) {
+			return '';
+		}
 
 		// Oh, how I'd like PHP 8's match()...
 		switch ( $this->get_option( 'auto_description_html_method' ) ) {
@@ -1110,8 +1128,9 @@ class Sanitize extends Admin_Pages {
 			$excerpt = $this->strip_tags_cs( \strip_shortcodes( $excerpt ), $strip_args );
 		}
 
-		if ( $escape )
+		if ( $escape ) {
 			return $this->s_description( $excerpt );
+		}
 
 		return $this->s_description_raw( $excerpt );
 	}
@@ -1349,10 +1368,13 @@ class Sanitize extends Admin_Pages {
 	 */
 	public function s_disabled_post_types( $new_values ) {
 
-		if ( ! \is_array( $new_values ) ) return [];
+		if ( ! \is_array( $new_values ) ) {
+			return [];
+		}
 
-		foreach ( $this->get_forced_supported_post_types() as $forced )
+		foreach ( $this->get_forced_supported_post_types() as $forced ) {
 			unset( $new_values[ $forced ] );
+		}
 
 		return $this->s_post_types( $new_values );
 	}
@@ -1369,10 +1391,13 @@ class Sanitize extends Admin_Pages {
 	 */
 	public function s_post_types( $new_values ) {
 
-		if ( ! \is_array( $new_values ) ) return [];
+		if ( ! \is_array( $new_values ) ) {
+			return [];
+		}
 
-		foreach ( $new_values as &$value )
+		foreach ( $new_values as &$value ) {
 			$value = $this->s_one_zero( $value );
+		}
 
 		return $new_values;
 	}
@@ -1389,10 +1414,13 @@ class Sanitize extends Admin_Pages {
 	 */
 	public function s_disabled_taxonomies( $new_values ) {
 
-		if ( ! \is_array( $new_values ) ) return [];
+		if ( ! \is_array( $new_values ) ) {
+			return [];
+		}
 
-		foreach ( $this->get_forced_supported_taxonomies() as $forced )
+		foreach ( $this->get_forced_supported_taxonomies() as $forced ) {
 			unset( $new_values[ $forced ] );
+		}
 
 		return $this->s_taxonomies( $new_values );
 	}
@@ -1587,14 +1615,19 @@ class Sanitize extends Admin_Pages {
 		$new_value = $this->s_tabs( $new_value );
 		$new_value = trim( $new_value );
 
-		if ( empty( $new_value ) ) return '';
+		if ( empty( $new_value ) ) {
+			return '';
+		}
 
 		$profile = trim( $this->s_relative_url( $new_value ), ' /' );
 
-		if ( '@' === $profile ) return '';
+		if ( '@' === $profile ) {
+			return '';
+		}
 
-		if ( '@' !== substr( $profile, 0, 1 ) )
+		if ( '@' !== substr( $profile, 0, 1 ) ) {
 			$profile = "@$profile";
+		}
 
 		return str_replace( [ ' ', "\t" ], '', $profile );
 	}
@@ -1620,11 +1653,15 @@ class Sanitize extends Admin_Pages {
 		$new_value = $this->s_tabs( $new_value );
 		$new_value = trim( $new_value );
 
-		if ( empty( $new_value ) ) return '';
+		if ( empty( $new_value ) ) {
+			return '';
+		}
 
 		$path = trim( $this->s_relative_url( $new_value ), ' /' );
 
-		if ( ! $path ) return '';
+		if ( ! $path ) {
+			return '';
+		}
 
 		$link = "https://www.facebook.com/{$path}";
 
@@ -1661,12 +1698,15 @@ class Sanitize extends Admin_Pages {
 
 		$key = \array_key_exists( $new_value, $card );
 
-		if ( $key ) return (string) $new_value;
+		if ( $key ) {
+			return (string) $new_value;
+		}
 
 		$previous = $this->get_option( 'twitter_card' );
 
-		if ( empty( $previous ) )
+		if ( empty( $previous ) ) {
 			$previous = $this->get_default_option( 'twitter_card' );
+		}
 
 		return (string) $previous;
 	}
@@ -1706,11 +1746,14 @@ class Sanitize extends Admin_Pages {
 		// phpcs:ignore, WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- This is simple, performant sanity.
 		$url = strip_tags( $new_value );
 
-		if ( ! $url ) return '';
+		if ( ! $url ) {
+			return '';
+		}
 
 		// This is also checked when performing a redirect.
-		if ( ! $this->allow_external_redirect() )
+		if ( ! $this->allow_external_redirect() ) {
 			$url = $this->set_url_scheme( $url, 'relative' );
+		}
 
 		// Only adjust scheme if it used to be relative. Do not use `s_url_relative_to_current_scheme()`.
 		$url = $this->convert_to_url_if_path( $url );
@@ -1758,11 +1801,13 @@ class Sanitize extends Admin_Pages {
 
 		$color = trim( $new_value, '# ' );
 
-		if ( '' === $color )
+		if ( '' === $color ) {
 			return '';
+		}
 
-		if ( preg_match( '/^([A-Fa-f0-9]{3}){1,2}$/', $color ) )
+		if ( preg_match( '/^([A-Fa-f0-9]{3}){1,2}$/', $color ) ) {
 			return $color;
+		}
 
 		return '';
 	}
@@ -1845,8 +1890,9 @@ class Sanitize extends Admin_Pages {
 			'http',
 		];
 
-		if ( \in_array( $new_value, $accepted_values, true ) )
+		if ( \in_array( $new_value, $accepted_values, true ) ) {
 			return (string) $new_value;
+		}
 
 		return 'automatic';
 	}
@@ -2010,7 +2056,9 @@ class Sanitize extends Admin_Pages {
 	 */
 	public function strip_tags_cs( $input, $args = [] ) {
 
-		if ( false === strpos( $input, '<' ) ) return $input;
+		if ( false === strpos( $input, '<' ) ) {
+			return $input;
+		}
 
 		/**
 		 * Find the optimized version in `s_excerpt()`. The defaults here treats HTML for a18y reading, not description generation.
@@ -2040,8 +2088,9 @@ class Sanitize extends Admin_Pages {
 			$args = $default_args;
 		} else {
 			// We don't use array_merge() here because we want to default these to [] when $args is given.
-			foreach ( [ 'clear', 'space' ] as $type )
+			foreach ( [ 'clear', 'space' ] as $type ) {
 				$args[ $type ] = (array) ( $args[ $type ] ?? [] );
+			}
 
 			$args['strip']  = $args['strip'] ?? $default_args['strip'];
 			$args['passes'] = $args['passes'] ?? $default_args['passes'];
@@ -2088,7 +2137,9 @@ class Sanitize extends Admin_Pages {
 
 		foreach ( $parse as $query_type => $handles ) {
 			foreach ( $handles as $flow_type => $elements ) {
-				if ( false === strpos( $input, '<' ) || ! $elements ) break 2;
+				if ( false === strpos( $input, '<' ) || ! $elements ) {
+					break 2;
+				}
 
 				switch ( $query_type ) {
 					case 'void_query':
@@ -2129,7 +2180,9 @@ class Sanitize extends Admin_Pages {
 								$input
 							) ?? '';
 							// If nothing changed, or no more HTML is present, we're done.
-							if ( $pre_pass_input === $input || false === strpos( $input, '<' ) ) break;
+							if ( $pre_pass_input === $input || false === strpos( $input, '<' ) ) {
+								break;
+							}
 						}
 						// Reset for next fall-through null-coalescing.
 						unset( $passes, $replacement );
@@ -2166,8 +2219,9 @@ class Sanitize extends Admin_Pages {
 	public function s_image_details( $details ) {
 
 		// This is 350x faster than a polyfill for `array_is_list()`.
-		if ( array_values( $details ) === $details )
+		if ( array_values( $details ) === $details ) {
 			return $this->s_image_details_deep( $details );
+		}
 
 		$defaults = [
 			'url'      => '',
@@ -2180,11 +2234,15 @@ class Sanitize extends Admin_Pages {
 
 		[ $url, $id, $width, $height, $alt, $filesize ] = array_values( array_merge( $defaults, $details ) );
 
-		if ( ! $url ) return $defaults;
+		if ( ! $url ) {
+			return $defaults;
+		}
 
 		$url = $this->s_url_relative_to_current_scheme( $url );
 
-		if ( ! $url ) return $defaults;
+		if ( ! $url ) {
+			return $defaults;
+		}
 
 		/**
 		 * Skip APNG, BMP, ICO, TIFF, and SVG.
@@ -2202,20 +2260,25 @@ class Sanitize extends Admin_Pages {
 			strtolower( strtok( pathinfo( $url, \PATHINFO_EXTENSION ), '?' ) ),
 			[ 'apng', 'bmp', 'ico', 'cur', 'svg', 'tif', 'tiff' ],
 			true
-		) ) return $defaults;
+		) ) {
+			return $defaults;
+		}
 
 		$width  = \absint( $width );
 		$height = \absint( $height );
 
-		if ( ! $width || ! $height )
+		if ( ! $width || ! $height ) {
 			$width = $height = 0;
+		}
 
 		// TODO add filter for 5 * \MB_IN_BYTES; Facebook allows 8MB; Twitter 5MB (Q4 2022).
 		if ( $id && ( $width > 4096 || $height > 4096 || $filesize > 5 * \MB_IN_BYTES ) ) {
 			$new_image = $this->get_largest_acceptable_image_src( $id, 4096, 5 * \MB_IN_BYTES );
 			$url       = $new_image ? $this->s_url_relative_to_current_scheme( $new_image[0] ) : '';
 
-			if ( ! $url ) return $defaults;
+			if ( ! $url ) {
+				return $defaults;
+			}
 
 			// No sanitization needed. PHP's getimagesize() returns the correct values.
 			$width  = $new_image[1];
@@ -2253,11 +2316,13 @@ class Sanitize extends Admin_Pages {
 		$cleaned_details = [];
 
 		// Failsafe. Convert associative details to a multidimensional sequential array.
-		if ( isset( $details_array['url'] ) )
+		if ( isset( $details_array['url'] ) ) {
 			$details_array = [ $details_array ];
+		}
 
-		foreach ( $details_array as $details )
+		foreach ( $details_array as $details ) {
 			$cleaned_details[] = $this->s_image_details( $details );
+		}
 
 		return array_values(
 			array_intersect_key(
@@ -2287,8 +2352,9 @@ class Sanitize extends Admin_Pages {
 
 		if ( \is_array( $value ) ) {
 			foreach ( $value as $v ) {
-				if ( $this->set_and_strlen( $var, $v ) )
+				if ( $this->set_and_strlen( $var, $v ) ) {
 					return true;
+				}
 			}
 			return false;
 		}

--- a/inc/classes/site-options.class.php
+++ b/inc/classes/site-options.class.php
@@ -354,8 +354,9 @@ class Site_Options extends Sanitize {
 			$val = $this->get_all_options( \THE_SEO_FRAMEWORK_SITE_OPTIONS, true );
 
 			// This loop digs through itself: $val[ $index ][ $index ]... etc.
-			foreach ( (array) $key as $k )
+			foreach ( (array) $key as $k ) {
 				$val = $val[ $k ] ?? '';
+			}
 
 			return ! empty( $val ) ? \stripslashes_deep( $val ) : '';
 		}
@@ -363,14 +364,16 @@ class Site_Options extends Sanitize {
 		static $cache;
 
 		// PHP 7.4: null coalesce equal operator: ??=
-		if ( ! isset( $cache ) )
+		if ( ! isset( $cache ) ) {
 			$cache = \stripslashes_deep( $this->get_all_options( \THE_SEO_FRAMEWORK_SITE_OPTIONS ) );
+		}
 
 		$val = $cache;
 
 		// This loop digs through itself: $val[ $index ][ $index ]... etc.
-		foreach ( (array) $key as $k )
+		foreach ( (array) $key as $k ) {
 			$val = $val[ $k ] ?? '';
+		}
 
 		return $val;
 	}
@@ -398,11 +401,13 @@ class Site_Options extends Sanitize {
 
 		static $cache = [];
 
-		if ( ! $setting )
+		if ( ! $setting ) {
 			$setting = \THE_SEO_FRAMEWORK_SITE_OPTIONS;
+		}
 
-		if ( ! $reset && isset( $cache[ $setting ] ) )
+		if ( ! $reset && isset( $cache[ $setting ] ) ) {
 			return $cache[ $setting ];
+		}
 
 		/**
 		 * @since 2.0.0
@@ -444,8 +449,9 @@ class Site_Options extends Sanitize {
 			?? umemo( __METHOD__, \stripslashes_deep( $this->get_default_site_options() ) );
 
 		// This loop digs through itself: $val[ $index ][ $index ]... etc.
-		foreach ( (array) $key as $k )
+		foreach ( (array) $key as $k ) {
 			$val = $val[ $k ] ?? null;
+		}
 
 		return $val ?? null;
 	}
@@ -466,8 +472,9 @@ class Site_Options extends Sanitize {
 			?? umemo( __METHOD__, \stripslashes_deep( $this->get_warned_site_options() ) );
 
 		// This loop digs through itself: $val[ $index ][ $index ]... etc.
-		foreach ( (array) $key as $k )
+		foreach ( (array) $key as $k ) {
 			$val = $val[ $k ] ?? null;
+		}
 
 		return (bool) ( $val ?? false );
 	}
@@ -493,8 +500,9 @@ class Site_Options extends Sanitize {
 		$this->check_options_reset();
 
 		// Handle post-update actions. Must be initialized on admin_init and is initialized on options.php.
-		if ( 'options.php' === $GLOBALS['pagenow'] )
+		if ( 'options.php' === $GLOBALS['pagenow'] ) {
 			$this->process_settings_submission();
+		}
 	}
 
 	/**
@@ -541,8 +549,9 @@ class Site_Options extends Sanitize {
 	protected function check_options_reset() {
 
 		// Check if we're already dealing with the settings. Buggy cache might interfere, otherwise.
-		if ( ! $this->is_seo_settings_page( false ) || ! $this->can_access_settings() )
+		if ( ! $this->is_seo_settings_page( false ) || ! $this->can_access_settings() ) {
 			return;
+		}
 
 		if ( $this->get_option( 'tsf-settings-reset', false ) ) {
 			if ( \update_option( \THE_SEO_FRAMEWORK_SITE_OPTIONS, $this->get_default_site_options() ) ) {
@@ -802,7 +811,9 @@ class Site_Options extends Sanitize {
 	public function get_post_type_archive_meta( $post_type, $use_cache = true ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( $use_cache && ( $memo = memo( null, $post_type ) ) ) return $memo;
+		if ( $use_cache && ( $memo = memo( null, $post_type ) ) ) {
+			return $memo;
+		}
 
 		/**
 		 * We can't trust the filter to always contain the expected keys.
@@ -870,8 +881,9 @@ class Site_Options extends Sanitize {
 	 */
 	public function get_all_post_type_archive_meta_defaults() {
 
-		foreach ( $this->get_public_post_type_archives() as $pta )
+		foreach ( $this->get_public_post_type_archives() as $pta ) {
 			$defaults[ $pta ] = $this->get_post_type_archive_meta_defaults( $pta );
+		}
 
 		return $defaults ?? [];
 	}

--- a/inc/classes/term-data.class.php
+++ b/inc/classes/term-data.class.php
@@ -84,7 +84,9 @@ class Term_Data extends Post_Data {
 	public function get_term_meta( $term_id, $use_cache = true ) {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( $use_cache && ( $memo = memo( null, $term_id ) ) ) return $memo;
+		if ( $use_cache && ( $memo = memo( null, $term_id ) ) ) {
+			return $memo;
+		}
 
 		$term = \get_term( $term_id );
 
@@ -244,7 +246,9 @@ class Term_Data extends Post_Data {
 			|| ! \current_user_can( 'edit_term', $term->term_id )
 			|| ! isset( $_POST['_wpnonce'] )
 			|| ! \wp_verify_nonce( $_POST['_wpnonce'], "update-tag_{$term->term_id}" )
-		) return;
+		) {
+			return;
+		}
 
 		$data = (array) $_POST['autodescription-meta'];
 
@@ -274,7 +278,9 @@ class Term_Data extends Post_Data {
 			   empty( $term->term_id ) // We could test for is_wp_error( $term ), but this is more to the point.
 			|| ! \current_user_can( 'edit_term', $term->term_id )
 			|| ! \check_ajax_referer( 'taxinlineeditnonce', '_inline_edit', false )
-		) return;
+		) {
+			return;
+		}
 
 		// Unlike the term-edit saving, we don't reset the data, just overwrite what's given.
 		// This is because we only update a portion of the meta.
@@ -309,7 +315,9 @@ class Term_Data extends Post_Data {
 		$term = \get_term( $term_id, $taxonomy );
 
 		// We could test for is_wp_error( $term ), but this is more to the point.
-		if ( empty( $term->term_id ) ) return;
+		if ( empty( $term->term_id ) ) {
+			return;
+		}
 
 		$meta          = $this->get_term_meta( $term->term_id, false );
 		$meta[ $item ] = $value;
@@ -334,7 +342,9 @@ class Term_Data extends Post_Data {
 		$term = \get_term( $term_id, $taxonomy );
 
 		// We could test for is_wp_error( $term ), but this is more to the point.
-		if ( empty( $term->term_id ) ) return;
+		if ( empty( $term->term_id ) ) {
+			return;
+		}
 
 		$data = (array) \wp_parse_args( $data, $this->get_term_meta_defaults( $term->term_id ) );
 		$data = $this->s_term_meta( $data );
@@ -375,8 +385,9 @@ class Term_Data extends Post_Data {
 		$data = \get_term_meta( $term_id, \THE_SEO_FRAMEWORK_TERM_OPTIONS, true );
 
 		if ( \is_array( $data ) ) {
-			foreach ( $this->get_term_meta_defaults( $term_id ) as $key => $value )
+			foreach ( $this->get_term_meta_defaults( $term_id ) as $key => $value ) {
 				unset( $data[ $key ] );
+			}
 		}
 
 		// Only delete when no values are left, because someone else might've filtered it.
@@ -401,7 +412,9 @@ class Term_Data extends Post_Data {
 	public function get_latest_category_id() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$cats = \get_terms( [
 			'taxonomy'   => 'category',
@@ -476,8 +489,9 @@ class Term_Data extends Post_Data {
 
 		$post_type = $post_type ?: $this->get_current_post_type();
 
-		if ( ! $post_type )
+		if ( ! $post_type ) {
 			return [];
+		}
 
 		$taxonomies = \get_object_taxonomies( $post_type, 'objects' );
 		$taxonomies = array_filter(

--- a/inc/classes/user-data.class.php
+++ b/inc/classes/user-data.class.php
@@ -103,13 +103,16 @@ class User_Data extends Term_Data {
 	 */
 	public function get_user_meta( $user_id = 0, $use_cache = true, $depr = true ) {
 
-		if ( false === $depr ) $use_cache = false;
+		if ( false === $depr ) {
+			$use_cache = false;
+		}
 
 		$user_id = $user_id ?: $this->get_user_id();
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( $use_cache && null !== $memo = memo( null, $user_id ) )
+		if ( $use_cache && null !== $memo = memo( null, $user_id ) ) {
 			return $memo;
+		}
 
 		/**
 		 * We can't trust the filter to always contain the expected keys.
@@ -129,9 +132,13 @@ class User_Data extends Term_Data {
 				$_meta = \get_user_meta( $user_id, \THE_SEO_FRAMEWORK_USER_OPTIONS, true ) ?: [];
 
 				foreach ( $this->get_headless_user_meta_support() as $meta_key => $supports ) {
-					if ( ! isset( $_meta[ $meta_key ] ) ) continue;
+					if ( ! isset( $_meta[ $meta_key ] ) ) {
+						continue;
+					}
 					foreach ( $supports as $support_type ) {
-						if ( $this->is_headless[ $support_type ] ) continue;
+						if ( $this->is_headless[ $support_type ] ) {
+							continue;
+						}
 						$meta[ $meta_key ] = $_meta[ $meta_key ];
 						continue 2;
 					}
@@ -210,14 +217,20 @@ class User_Data extends Term_Data {
 	 */
 	public function _update_user_meta( $user_id ) {
 
-		if ( empty( $_POST ) ) return;
+		if ( empty( $_POST ) ) {
+			return;
+		}
 
 		\check_admin_referer( "update-user_{$user_id}" );
-		if ( ! \current_user_can( 'edit_user', $user_id ) ) return;
+		if ( ! \current_user_can( 'edit_user', $user_id ) ) {
+			return;
+		}
 
 		$user = \get_userdata( $user_id );
 
-		if ( ! $user->has_cap( \THE_SEO_FRAMEWORK_AUTHOR_INFO_CAP ) ) return;
+		if ( ! $user->has_cap( \THE_SEO_FRAMEWORK_AUTHOR_INFO_CAP ) ) {
+			return;
+		}
 
 		// We won't reset the data, just overwrite what's given.
 		// This is because we only update a portion of the meta.
@@ -243,7 +256,9 @@ class User_Data extends Term_Data {
 		$user = \get_userdata( $user_id );
 
 		// We could test for !$user, but this is more to the point.
-		if ( empty( $user->ID ) ) return;
+		if ( empty( $user->ID ) ) {
+			return;
+		}
 
 		$meta            = $this->get_user_meta( $user_id, false );
 		$meta[ $option ] = $value;
@@ -265,7 +280,9 @@ class User_Data extends Term_Data {
 		$user = \get_userdata( $user_id );
 
 		// We could test for !$user, but this is more to the point.
-		if ( empty( $user->ID ) ) return;
+		if ( empty( $user->ID ) ) {
+			return;
+		}
 
 		/**
 		 * @since 4.1.4
@@ -299,7 +316,9 @@ class User_Data extends Term_Data {
 	public function get_current_post_author_id() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		if ( $this->is_singular() ) {
 			$post      = \get_post( $this->get_the_real_ID() );
@@ -322,7 +341,9 @@ class User_Data extends Term_Data {
 	public function get_user_id() {
 
 		// phpcs:ignore, WordPress.CodeAnalysis.AssignmentInCondition -- I know.
-		if ( null !== $memo = memo() ) return $memo;
+		if ( null !== $memo = memo() ) {
+			return $memo;
+		}
 
 		$user = \wp_get_current_user();
 

--- a/inc/compat/plugin-bbpress.php
+++ b/inc/compat/plugin-bbpress.php
@@ -36,7 +36,9 @@ namespace The_SEO_Framework;
  */
 function _bbpress_filter_title( $title, $args ) {
 
-	if ( null !== $args || ! \is_bbpress() ) return $title;
+	if ( null !== $args || ! \is_bbpress() ) {
+		return $title;
+	}
 
 	// phpcs:disable, Squiz.Commenting.BlockComment, Generic.WhiteSpace.ScopeIndent, WordPress.WP.I18n, Generic.Formatting.MultipleStatementAlignment -- Not my code.
 
@@ -407,8 +409,9 @@ function _bbpress_filter_robots( $meta, $args, $options ) {
 		}
 	}
 
-	if ( ! empty( $forum_id ) && ! \bbp_is_forum_public( $forum_id ) )
+	if ( ! empty( $forum_id ) && ! \bbp_is_forum_public( $forum_id ) ) {
 		$meta['noindex'] = 'noindex';
+	}
 
 	return $meta;
 }
@@ -424,12 +427,16 @@ function _bbpress_filter_robots( $meta, $args, $options ) {
  */
 function _assert_bbpress_noindex_defaults_seo_bar( $interpreter ) {
 
-	if ( $interpreter::$query['taxonomy'] ) return;
+	if ( $interpreter::$query['taxonomy'] ) {
+		return;
+	}
 
 	$items = $interpreter::collect_seo_bar_items();
 
 	// Don't do anything if there's a blocking redirect.
-	if ( ! empty( $items['redirect']['meta']['blocking'] ) ) return;
+	if ( ! empty( $items['redirect']['meta']['blocking'] ) ) {
+		return;
+	}
 
 	switch ( $interpreter::$query['post_type'] ) {
 		case \bbp_get_forum_post_type():
@@ -441,7 +448,9 @@ function _assert_bbpress_noindex_defaults_seo_bar( $interpreter ) {
 			break;
 	}
 
-	if ( empty( $forum_id ) || \bbp_is_forum_public( $forum_id ) ) return;
+	if ( empty( $forum_id ) || \bbp_is_forum_public( $forum_id ) ) {
+		return;
+	}
 
 	$index_item           = &$interpreter::edit_seo_bar_item( 'indexing' );
 	$index_item['status'] =

--- a/inc/compat/plugin-polylang.php
+++ b/inc/compat/plugin-polylang.php
@@ -64,7 +64,9 @@ function _polylang_fix_sitemap_base_bath( $path ) {
  */
 function _polylang_set_sitemap_language() {
 
-	if ( ! \function_exists( '\\PLL' ) || ! ( \PLL() instanceof \PLL_Frontend ) ) return;
+	if ( ! \function_exists( '\\PLL' ) || ! ( \PLL() instanceof \PLL_Frontend ) ) {
+		return;
+	}
 
 	// phpcs:ignore, WordPress.Security.NonceVerification.Recommended -- Arbitrary input expected.
 	$lang = $_GET['lang'] ?? '';
@@ -89,8 +91,9 @@ function _polylang_set_sitemap_language() {
 	// This will default to the default language when $lang is invalid or unregistered. This is fine.
 	$new_lang = \PLL()->model->get_language( $lang );
 
-	if ( $new_lang )
+	if ( $new_lang ) {
 		\PLL()->curlang = $new_lang;
+	}
 }
 
 \add_filter( 'the_seo_framework_sitemap_hpt_query_args', __NAMESPACE__ . '\\_polylang_sitemap_append_non_translatables' );
@@ -122,13 +125,19 @@ function _polylang_sitemap_append_non_translatables( $args ) {
 			'pll_languages_list',
 			'pll_default_language',
 		],
-	] ) ) return $args;
+	] ) ) {
+		return $args;
+	}
 
-	if ( ! ( \PLL() instanceof \PLL_Frontend ) ) return $args;
+	if ( ! ( \PLL() instanceof \PLL_Frontend ) ) {
+		return $args;
+	}
 
 	$default_lang = \pll_default_language( \OBJECT );
 
-	if ( ! isset( $default_lang->slug, $default_lang->term_id ) ) return $args;
+	if ( ! isset( $default_lang->slug, $default_lang->term_id ) ) {
+		return $args;
+	}
 
 	if ( ( \PLL()->curlang->slug ?? null ) === $default_lang->slug ) {
 		$args['lang']      = ''; // Select all lang, so that Polylang doesn't affect the query below with an AND (we need OR).
@@ -173,9 +182,11 @@ function _polylang_sitemap_append_non_translatables( $args ) {
  * @return string
  */
 function pll__( $string ) {
-	if ( \function_exists( '\\PLL' ) && \function_exists( '\\pll__' ) )
-		if ( \PLL() instanceof \PLL_Frontend )
+	if ( \function_exists( '\\PLL' ) && \function_exists( '\\pll__' ) ) {
+		if ( \PLL() instanceof \PLL_Frontend ) {
 			return \pll__( $string );
+		}
+	}
 
 	return $string;
 }
@@ -250,7 +261,9 @@ function _polylang_fix_home_url( $url ) {
  */
 function _polylang_flush_sitemap( $type, $id, $args, $success ) {
 
-	if ( ! $success ) return;
+	if ( ! $success ) {
+		return;
+	}
 
 	global $wpdb;
 

--- a/inc/compat/plugin-ultimatemember.php
+++ b/inc/compat/plugin-ultimatemember.php
@@ -23,7 +23,9 @@ function _um_reinstate_title_support() {
 			'um_is_core_page',
 			'um_get_requested_user',
 		],
-	] ) ) return;
+	] ) ) {
+		return;
+	}
 
 	if ( \um_is_core_page( 'user' ) && \um_get_requested_user() ) {
 		// This number has nothing to do with the reasoning hereinbefore -- merely to reflect their API.
@@ -45,14 +47,18 @@ function _um_reinstate_title_support() {
 function _um_determine_support( $supported = true ) {
 
 	// No need to modify support if it's already not supported.
-	if ( ! $supported ) return $supported;
+	if ( ! $supported ) {
+		return $supported;
+	}
 
 	if ( ! \tsf()->can_i_use( [
 		'functions' => [
 			'um_queried_user',
 			'um_is_core_page',
 		],
-	] ) ) return $supported;
+	] ) ) {
+		return $supported;
+	}
 
 	/**
 	 * We do not test for 'um_get_requested_user()' -- but this is safe.

--- a/inc/compat/plugin-woocommerce.php
+++ b/inc/compat/plugin-woocommerce.php
@@ -88,8 +88,9 @@ function _is_shop( $post = null ) {
 function _set_real_id_wc_shop( $id ) {
 
 	// phpcs:ignore, TSF.Performance.Opcodes.ShouldHaveNamespaceEscape -- local func
-	if ( _is_shop() )
+	if ( _is_shop() ) {
 		$id = (int) \get_option( 'woocommerce_shop_page_id' );
+	}
 
 	return $id;
 }
@@ -141,7 +142,9 @@ function _set_wc_is_shop( $is_shop, $post ) {
  */
 function _set_wc_is_product( $is_product, $post ) {
 
-	if ( $is_product ) return $is_product;
+	if ( $is_product ) {
+		return $is_product;
+	}
 
 	if ( $post ) {
 		$is_product = 'product' === \get_post_type( $post );
@@ -166,7 +169,9 @@ function _set_wc_is_product( $is_product, $post ) {
  */
 function _set_wc_is_product_admin( $is_product_admin ) {
 
-	if ( $is_product_admin ) return $is_product_admin;
+	if ( $is_product_admin ) {
+		return $is_product_admin;
+	}
 
 	$tsf = \tsf();
 
@@ -202,31 +207,41 @@ function _set_wc_is_product_admin( $is_product_admin ) {
 function _set_wc_noindex_defaults( $meta, $args, $options ) {
 
 	// Nothing to do here...
-	if ( 'noindex' === $meta['noindex'] ) return $meta;
+	if ( 'noindex' === $meta['noindex'] ) {
+		return $meta;
+	}
 
 	$tsf = \tsf();
 
 	if ( null === $args ) {
-		if ( $tsf->is_singular() )
+		if ( $tsf->is_singular() ) {
 			$page_id = $tsf->get_the_real_ID();
+		}
 	} else {
-		if ( '' === $args['taxonomy'] )
+		if ( '' === $args['taxonomy'] ) {
 			$page_id = $args['id'];
+		}
 	}
 
 	// No page_id was found: unsupported query.
-	if ( empty( $page_id ) ) return $meta;
+	if ( empty( $page_id ) ) {
+		return $meta;
+	}
 
 	static $page_ids;
 
 	if ( ! isset( $page_ids ) ) {
-		if ( ! \function_exists( '\\wc_get_page_id' ) ) return $meta;
+		if ( ! \function_exists( '\\wc_get_page_id' ) ) {
+			return $meta;
+		}
 
 		$page_ids = array_filter( [ \wc_get_page_id( 'cart' ), \wc_get_page_id( 'checkout' ), \wc_get_page_id( 'myaccount' ) ] );
 	}
 
 	// This current page isn't a WC cart/checkout/myaccount page.
-	if ( ! \in_array( $page_id, $page_ids, true ) ) return $meta;
+	if ( ! \in_array( $page_id, $page_ids, true ) ) {
+		return $meta;
+	}
 
 	// Set the default to 'noindex' if settings are ignored, or if the setting is set to "default" (0).
 	if (
@@ -250,19 +265,26 @@ function _set_wc_noindex_defaults( $meta, $args, $options ) {
  */
 function _assert_wc_noindex_defaults_seo_bar( $interpreter ) {
 
-	if ( $interpreter::$query['taxonomy'] ) return;
+	if ( $interpreter::$query['taxonomy'] ) {
+		return;
+	}
 
 	static $page_ids;
 
-	if ( ! isset( $page_ids ) )
+	if ( ! isset( $page_ids ) ) {
 		$page_ids = array_filter( [ \wc_get_page_id( 'cart' ), \wc_get_page_id( 'checkout' ), \wc_get_page_id( 'myaccount' ) ] );
+	}
 
-	if ( ! \in_array( $interpreter::$query['id'], $page_ids, true ) ) return;
+	if ( ! \in_array( $interpreter::$query['id'], $page_ids, true ) ) {
+		return;
+	}
 
 	$items = $interpreter::collect_seo_bar_items();
 
 	// Don't do anything if there's a blocking redirect.
-	if ( ! empty( $items['redirect']['meta']['blocking'] ) ) return;
+	if ( ! empty( $items['redirect']['meta']['blocking'] ) ) {
+		return;
+	}
 
 	$index_item                         = &$interpreter::edit_seo_bar_item( 'indexing' );
 	$index_item['status']               =
@@ -311,11 +333,13 @@ function _adjust_wc_image_generation_params( $params, $args ) {
 		}
 	}
 
-	if ( $is_product )
+	if ( $is_product ) {
 		$params['cbs']['wc_gallery'] = __NAMESPACE__ . '\\_get_product_gallery_image_details';
+	}
 
-	if ( $is_product_category )
+	if ( $is_product_category ) {
 		$params['cbs']['wc_thumbnail'] = __NAMESPACE__ . '\\_get_product_category_thumbnail_image_details';
+	}
 
 	return $params;
 }

--- a/inc/compat/plugin-wpforo.php
+++ b/inc/compat/plugin-wpforo.php
@@ -21,7 +21,9 @@ namespace The_SEO_Framework;
  */
 function _wpforo_fix_page() {
 
-	if ( \is_admin() || ! \function_exists( '\\is_wpforo_page' ) || ! \is_wpforo_page() ) return;
+	if ( \is_admin() || ! \function_exists( '\\is_wpforo_page' ) || ! \is_wpforo_page() ) {
+		return;
+	}
 
 	if ( _wpforo_seo_title_enabled() ) { // phpcs:ignore, TSF.Performance.Opcodes -- is local.
 		\add_filter( 'the_seo_framework_title_from_generation', __NAMESPACE__ . '\\_wpforo_filter_pre_title', 10, 2 );
@@ -107,20 +109,28 @@ function _wpforo_filter_pre_title( $title = '', $args = null ) {
  */
 function _assert_wpforo_page_seo_bar( $interpreter ) {
 
-	if ( $interpreter::$query['taxonomy'] ) return;
+	if ( $interpreter::$query['taxonomy'] ) {
+		return;
+	}
 
 	$meta_enabled  = _wpforo_seo_meta_enabled();   // phpcs:ignore, TSF.Performance.Opcodes -- is local.
 	$title_enabled = _wpforo_seo_title_enabled(); // phpcs:ignore, TSF.Performance.Opcodes -- is local.
 
-	if ( ! $meta_enabled && ! $title_enabled ) return;
+	if ( ! $meta_enabled && ! $title_enabled ) {
+		return;
+	}
 
 	$items = &$interpreter::collect_seo_bar_items();
 
 	// Don't do anything if there's a blocking redirect.
-	if ( ! empty( $items['redirect']['meta']['blocking'] ) ) return;
+	if ( ! empty( $items['redirect']['meta']['blocking'] ) ) {
+		return;
+	}
 
 	// Skip if we're not dealing with the wpForo page.
-	if ( ! \has_shortcode( \tsf()->get_post_content( $interpreter::$query['id'] ), 'wpforo' ) ) return;
+	if ( ! \has_shortcode( \tsf()->get_post_content( $interpreter::$query['id'] ), 'wpforo' ) ) {
+		return;
+	}
 
 	foreach ( $items as $id => &$item ) {
 		switch ( $id ) {
@@ -128,10 +138,14 @@ function _assert_wpforo_page_seo_bar( $interpreter ) {
 				// Preserve redirect, for TSF still manages that.
 				continue 2;
 			case 'title':
-				if ( ! $title_enabled ) continue 2;
+				if ( ! $title_enabled ) {
+					continue 2;
+				}
 				break;
 			default:
-				if ( ! $meta_enabled ) continue 2;
+				if ( ! $meta_enabled ) {
+					continue 2;
+				}
 				break;
 		}
 

--- a/inc/compat/plugin-wpml.php
+++ b/inc/compat/plugin-wpml.php
@@ -65,7 +65,9 @@ function _wpml_remove_all_languages( $languages_links = [] ) {
  */
 function _wpml_flush_sitemap( $type, $id, $args, $success ) {
 
-	if ( ! $success ) return;
+	if ( ! $success ) {
+		return;
+	}
 
 	global $wpdb;
 
@@ -118,10 +120,13 @@ function _wpml_sitemap_filter_non_translatables( $args ) {
 	if ( empty( $sitepress )
 	|| ! method_exists( $sitepress, 'get_default_language' )
 	|| ! method_exists( $sitepress, 'get_current_language' )
-	|| ! method_exists( $sitepress, 'is_translated_post_type' ) )
+	|| ! method_exists( $sitepress, 'is_translated_post_type' ) ) {
 		return $args;
+	}
 
-	if ( $sitepress->get_default_language() === $sitepress->get_current_language() ) return $args;
+	if ( $sitepress->get_default_language() === $sitepress->get_current_language() ) {
+		return $args;
+	}
 
 	// Filter out only 'Not translatable'.
 	$args['post_type'] = array_filter( (array) $args['post_type'], [ $sitepress, 'is_translated_post_type' ] );

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -85,8 +85,9 @@ namespace {
 	function the_seo_framework_class() {
 
 		// did_action() returns true for current action match, too.
-		if ( ! did_action( 'plugins_loaded' ) )
+		if ( ! did_action( 'plugins_loaded' ) ) {
 			return false;
+		}
 
 		return get_class( tsf() );
 	}
@@ -176,8 +177,9 @@ namespace The_SEO_Framework {
 			+ debug_backtrace( \DEBUG_BACKTRACE_IGNORE_ARGS, 2 )[1]
 		);
 
-		if ( isset( $value_to_set ) )
+		if ( isset( $value_to_set ) ) {
 			return $memo[ $hash ] = $value_to_set;
+		}
 
 		return $memo[ $hash ] ?? null;
 	}
@@ -226,8 +228,9 @@ namespace The_SEO_Framework {
 		// phpcs:ignore, WordPress.PHP.DiscouragedPHPFunctions -- No objects are inserted, nor is this ever unserialized.
 		$hash = serialize( [ $key, $args ] );
 
-		if ( isset( $value_to_set ) )
+		if ( isset( $value_to_set ) ) {
 			return $memo[ $hash ] = $value_to_set;
+		}
 
 		return $memo[ $hash ] ?? null;
 	}

--- a/inc/functions/upgrade-suggestion.php
+++ b/inc/functions/upgrade-suggestion.php
@@ -62,11 +62,17 @@ function _prepare( $previous_version, $current_version ) {
 
 	// 0
 	// phpcs:ignore, WordPress.PHP.StrictComparisons.LooseComparison -- might be mixed types.
-	if ( $previous_version == $current_version ) return;
+	if ( $previous_version == $current_version ) {
+		return;
+	}
 	// 1
-	if ( \defined( 'TSF_DISABLE_SUGGESTIONS' ) && \TSF_DISABLE_SUGGESTIONS ) return;
+	if ( \defined( 'TSF_DISABLE_SUGGESTIONS' ) && \TSF_DISABLE_SUGGESTIONS ) {
+		return;
+	}
 	// 2
-	if ( ! \is_main_site() ) return;
+	if ( ! \is_main_site() ) {
+		return;
+	}
 
 	$show_sale = true;
 	if ( \function_exists( '\\tsf_extension_manager' ) && method_exists( \tsf_extension_manager(), 'is_connected_user' ) ) {

--- a/inc/views/edit/wrap-content.php
+++ b/inc/views/edit/wrap-content.php
@@ -46,8 +46,9 @@ foreach ( $tabs as $tab => $params ) :
 			<?php
 		endif;
 
-		if ( ! empty( $params['callback'] ) )
+		if ( ! empty( $params['callback'] ) ) {
 			call_user_func_array( $params['callback'], ( $params['args'] ?? [] ) );
+		}
 
 		/**
 		 * @since 4.2.0

--- a/inc/views/edit/wrap-nav.php
+++ b/inc/views/edit/wrap-nav.php
@@ -34,11 +34,13 @@ if ( $use_tabs ) :
 				$input_id      = esc_attr( "tsf-flex-{$id}-tab-{$tab}" );
 				$input_name    = esc_attr( "tsf-flex-{$id}-tabs" );
 
-				if ( $dashicon )
+				if ( $dashicon ) {
 					$dashicon = sprintf( '<span class="tsf-flex dashicons %s tsf-flex-nav-dashicon"></span>', esc_attr( "dashicons-$dashicon" ) );
+				}
 
-				if ( $label_name )
+				if ( $label_name ) {
 					$label_name = sprintf( '<span class="tsf-flex tsf-flex-nav-name">%s</span>', esc_attr( $label_name ) );
+				}
 
 				// phpcs:ignore, WordPress.Security.EscapeOutput.OutputNotEscaped -- All output below is escaped.
 				echo <<<HTML

--- a/inc/views/notice/persistent.php
+++ b/inc/views/notice/persistent.php
@@ -11,7 +11,9 @@ use The_SEO_Framework\Interpreters\HTML;
 
 defined( 'THE_SEO_FRAMEWORK_PRESENT' ) and tsf()->_verify_include_secret( $_secret ) or die;
 
-if ( ! $message ) return;
+if ( ! $message ) {
+	return;
+}
 
 $sanitized_key = sanitize_key( $key );
 

--- a/inc/views/settings/columns.php
+++ b/inc/views/settings/columns.php
@@ -17,8 +17,9 @@ defined( 'THE_SEO_FRAMEWORK_PRESENT' ) and tsf()->_verify_include_secret( $_secr
 
 		do_meta_boxes( $this->seo_settings_page_hook, 'main', null );
 
-		if ( isset( $GLOBALS['wp_meta_boxes'][ $this->seo_settings_page_hook ]['main_extra'] ) )
+		if ( isset( $GLOBALS['wp_meta_boxes'][ $this->seo_settings_page_hook ]['main_extra'] ) ) {
 			do_meta_boxes( $this->seo_settings_page_hook, 'main_extra', null );
+		}
 
 		do_action( 'the_seo_framework_after_siteadmin_metaboxes', $this->seo_settings_page_hook );
 		?>

--- a/inc/views/settings/metaboxes/general.php
+++ b/inc/views/settings/metaboxes/general.php
@@ -253,7 +253,7 @@ switch ( $this->get_view_instance( 'general', $instance ) ) :
 				]
 			);
 			$_current     = $this->get_option( 'canonical_scheme' );
-			foreach ( $scheme_types as $value => $name )
+			foreach ( $scheme_types as $value => $name ) {
 				vprintf(
 					'<option value="%s" %s>%s</option>',
 					[
@@ -262,6 +262,7 @@ switch ( $this->get_view_instance( 'general', $instance ) ) :
 						esc_html( $name ),
 					]
 				);
+			}
 			?>
 		</select>
 
@@ -369,7 +370,9 @@ switch ( $this->get_view_instance( 'general', $instance ) ) :
 
 		foreach ( $this->get_public_post_types() as $post_type ) {
 			$_label = $this->get_post_type_label( $post_type, false );
-			if ( ! strlen( $_label ) ) continue;
+			if ( ! strlen( $_label ) ) {
+				continue;
+			}
 
 			$_label = sprintf(
 				'%s &ndash; <code>%s</code>',
@@ -400,7 +403,9 @@ switch ( $this->get_view_instance( 'general', $instance ) ) :
 
 		foreach ( $this->get_public_taxonomies() as $taxonomy ) {
 			$_label = $this->get_tax_type_label( $taxonomy, false );
-			if ( ! strlen( $_label ) ) continue;
+			if ( ! strlen( $_label ) ) {
+				continue;
+			}
 
 			$_label = sprintf(
 				'%s &ndash; <code>%s</code>',

--- a/inc/views/settings/metaboxes/homepage.php
+++ b/inc/views/settings/metaboxes/homepage.php
@@ -106,8 +106,9 @@ switch ( $this->get_view_instance( 'homepage', $instance ) ) :
 		<?php
 		HTML::description( __( 'Note: The input value of this field may be used to describe the name of the site elsewhere.', 'autodescription' ) );
 
-		if ( $home_id && $this->get_post_meta_item( '_genesis_title', $home_id ) )
+		if ( $home_id && $this->get_post_meta_item( '_genesis_title', $home_id ) ) {
 			HTML::description( __( 'Note: The title placeholder is fetched from the Page SEO Settings on the homepage.', 'autodescription' ) );
+		}
 
 		/**
 		 * @since 2.8.0

--- a/inc/views/settings/metaboxes/robots.php
+++ b/inc/views/settings/metaboxes/robots.php
@@ -306,8 +306,9 @@ switch ( $this->get_view_instance( 'robots', $instance ) ) :
 		HTML::description( __( 'These settings apply to the post type pages and their terms. When terms are shared between post types, all their post types should be checked for this to have an effect.', 'autodescription' ) );
 
 		// When the post OR page post types are available, show this warning.
-		if ( in_array( $ro_value, [ 'noindex', 'nofollow' ], true ) && array_intersect( $post_types, [ 'post', 'page' ] ) )
+		if ( in_array( $ro_value, [ 'noindex', 'nofollow' ], true ) && array_intersect( $post_types, [ 'post', 'page' ] ) ) {
 			HTML::attention_description( __( 'Warning: No site should enable these options for Posts and Pages.', 'autodescription' ) );
+		}
 
 		$checkboxes = [];
 
@@ -385,11 +386,12 @@ switch ( $this->get_view_instance( 'robots', $instance ) ) :
 			if ( 'site' === $type ) {
 				$checkboxes .= '<hr class=tsf-option-spacer>';
 
-				if ( in_array( $ro_value, [ 'noindex', 'nofollow' ], true ) )
+				if ( in_array( $ro_value, [ 'noindex', 'nofollow' ], true ) ) {
 					$checkboxes .= sprintf(
 						'<p><span class="description attention">%s</span></p>',
 						esc_html__( 'Warning: No public site should ever enable this option.', 'autodescription' )
 					);
+				}
 			}
 
 			$checkboxes .= Input::make_checkbox( [

--- a/inc/views/settings/metaboxes/schema.php
+++ b/inc/views/settings/metaboxes/schema.php
@@ -18,8 +18,9 @@ switch ( $this->get_view_instance( 'schema', $instance ) ) :
 	case 'schema_main':
 		HTML::header_title( __( 'Schema.org Output Settings', 'autodescription' ) );
 
-		if ( $this->has_json_ld_plugin() )
+		if ( $this->has_json_ld_plugin() ) {
 			HTML::attention_description( __( 'Another Schema.org plugin has been detected. These markup settings might conflict.', 'autodescription' ) );
+		}
 
 		HTML::description( __( 'The Schema.org markup is a standard way of annotating structured data for search engines. This markup is represented within hidden scripts throughout the website.', 'autodescription' ) );
 		HTML::description( __( 'When your web pages include structured data markup, search engines can use that data to index your content better, present it more prominently in search results, and use it in several different applications.', 'autodescription' ) );
@@ -128,7 +129,7 @@ switch ( $this->get_view_instance( 'schema', $instance ) ) :
 					]
 				);
 				$_current       = $this->get_option( 'knowledge_type' );
-				foreach ( $knowledge_type as $value => $name )
+				foreach ( $knowledge_type as $value => $name ) {
 					vprintf(
 						'<option value="%s" %s>%s</option>',
 						[
@@ -137,6 +138,7 @@ switch ( $this->get_view_instance( 'schema', $instance ) ) :
 							esc_html( $name ),
 						]
 					);
+				}
 				?>
 			</select>
 		</p>
@@ -305,7 +307,9 @@ switch ( $this->get_view_instance( 'schema', $instance ) ) :
 
 			foreach ( $socialsites as $sc ) {
 
-				if ( ! strlen( $this->get_option( $sc['option'] ) ) ) continue;
+				if ( ! strlen( $this->get_option( $sc['option'] ) ) ) {
+					continue;
+				}
 
 				?>
 				<p>

--- a/inc/views/settings/metaboxes/sitemaps.php
+++ b/inc/views/settings/metaboxes/sitemaps.php
@@ -114,7 +114,7 @@ switch ( $this->get_view_instance( 'sitemaps', $instance ) ) :
 				// TODO Also add a link telling where why it may not work consistently ('try opening in another browser, incognito, etc.')
 			} elseif ( $this->use_core_sitemaps() ) {
 				$_index_url = get_sitemap_url( 'index' );
-				if ( $_index_url )
+				if ( $_index_url ) {
 					HTML::description_noesc(
 						sprintf(
 							'<a href="%s" target=_blank rel=noopener>%s</a>',
@@ -122,6 +122,7 @@ switch ( $this->get_view_instance( 'sitemaps', $instance ) ) :
 							esc_html__( 'View the sitemap index.', 'autodescription' )
 						)
 					);
+				}
 			}
 
 			/**

--- a/inc/views/settings/metaboxes/social.php
+++ b/inc/views/settings/metaboxes/social.php
@@ -73,8 +73,9 @@ switch ( $this->get_view_instance( 'social', $instance ) ) :
 			] ),
 			true
 		);
-		if ( $this->detect_og_plugin() )
+		if ( $this->detect_og_plugin() ) {
 			HTML::attention_description( __( 'Note: Another Open Graph plugin has been detected. These meta tags might conflict.', 'autodescription' ) );
+		}
 
 		// Echo Facebook Tags checkbox.
 		HTML::wrap_fields(
@@ -95,8 +96,9 @@ switch ( $this->get_view_instance( 'social', $instance ) ) :
 			] ),
 			true
 		);
-		if ( $this->detect_twitter_card_plugin() )
+		if ( $this->detect_twitter_card_plugin() ) {
 			HTML::attention_description( __( 'Note: Another Twitter Card plugin has been detected. These meta tags might conflict.', 'autodescription' ) );
+		}
 
 		// Echo oEmbed scripts checkboxes.
 		HTML::wrap_fields(

--- a/inc/views/settings/wrap-content.php
+++ b/inc/views/settings/wrap-content.php
@@ -46,8 +46,9 @@ foreach ( $tabs as $tab => $params ) :
 			<?php
 		endif;
 
-		if ( ! empty( $params['callback'] ) )
+		if ( ! empty( $params['callback'] ) ) {
 			call_user_func_array( $params['callback'], [ ( $params['args'] ?? [] ) ] );
+		}
 
 		/**
 		 * @since 4.2.0

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,6 +27,9 @@
 		</properties>
 	</rule>
 
+	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
+	<rule ref="Squiz.ControlStructures.ControlSignature"/>
+
 	<!-- Exclude minified scripts. -->
 	<exclude-pattern>*.min.js</exclude-pattern>
 	<exclude-pattern>*.min.css</exclude-pattern>


### PR DESCRIPTION
From #634

> I'll leave control structures without braces. Indentation is leading and depicts the clause scope. There are 463 instances of this:

Many returns stood on one line with their ifs.

@sybrew Was done **by a machine**, not viktor!
```bash
vendor/bin/phpcbf -p --sniffs=Generic.ControlStructures.InlineControlStructure,Squiz.ControlStructures.ControlSignature,Generic.WhiteSpace.DisallowSpaceIndent,Generic.WhiteSpace.ScopeIndent autodescription.php bootstrap/ inc/
```

- Generic.ControlStructures.InlineControlStructure
- Squiz.ControlStructures.ControlSignature
- Generic.WhiteSpace.DisallowSpaceIndent
- Generic.WhiteSpace.ScopeIndent
