### PR TITLE
Add parent support of all types in Breadcrumbs

### DIFF
--- a/autodescription.php
+++ b/autodescription.php
@@ -3,7 +3,7 @@
  * Plugin Name: The SEO Framework
  * Plugin URI: https://theseoframework.com/
  * Description: An automated, advanced, accessible, unbranded and extremely fast SEO solution for your WordPress website.
- * Version: 5.0.2-dev-7
+ * Version: 5.0.2-dev-9
  * Author: The SEO Framework Team
  * Author URI: https://theseoframework.com/
  * License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -259,10 +259,14 @@ You can also output these breadcrumbs visually in your theme by [using a shortco
 * **Improved:**
 	* The breadcrumb shortcode now tries to remove inline margin in front of its text.
 		* And although we increased specificity, this may still be overwritten by the theme styles, which is intended behavior: enforcing styles makes theming difficult.
+	* In breadcrumbs, all post types now include their registered archive before any of their assigned terms.
+		* This will become togglable in a future update. Stay tuned!
+		* If you went out of your way implementing TSF's breadcrumbs, you may need to rethink and tweak that. Sorry about that! -- this is a brand new feature we're still learning about how to make it work better.
 * **Removed:**
 	* We temporarily removed support for the GitHub Updater because of unforeseen quirks, such as it renaming the plugin folder and updating from our development branch.
 		* In a future update, we'll reintroduce this with the quirks resolved.
 * **Fixed:**
+	* Resolved an issue where breadcrumbs included considered non-public taxonomies for their trail.
 	* Resolved an issue where term sitemaps wouldn't load when using the "not optimized" WordPress Core sitemaps.
 	* TODO Nested categories need to honor the primary but then the deepest one.
 		-> Is this a WC only issue?


### PR DESCRIPTION
This change makes breadcrumbs for posts always appear in this order:
1. Home
1. Post Type Archive
1. Primary Terms parents
1. Primary Term
1. Post parents
1. Post

This can be overwhelming, but it's the first step to allow control of (when) what's outputted.