### PR TITLE
Increase Chinese character_adjustments guidelines

### DIFF
--- a/inc/classes/helper/guidelines.class.php
+++ b/inc/classes/helper/guidelines.class.php
@@ -79,9 +79,9 @@ class Guidelines {
 			'ja'    =>  70 / 160, // Japanese (日本語)
 			'ko_KR' =>  82 / 160, // Korean (한국어)
 			'ta_IN' => 120 / 160, // Tamil (தமிழ்)
-			'zh_TW' =>  70 / 160, // Taiwanese Mandarin (Traditional Chinese) (繁體中文)
-			'zh_HK' =>  70 / 160, // Hong Kong (Chinese version) (香港中文版)
-			'zh_CN' =>  70 / 160, // Mandarin (Simplified Chinese) (简体中文)
+			'zh_TW' =>  110 / 160, // Taiwanese Mandarin (Traditional Chinese) (繁體中文)
+			'zh_HK' =>  110 / 160, // Hong Kong (Chinese version) (香港中文版)
+			'zh_CN' =>  110 / 160, // Mandarin (Simplified Chinese) (简体中文)
 		];
 		// phpcs:enable, WordPress.WhiteSpace.OperatorSpacing.SpacingAfter
 


### PR DESCRIPTION
The previous character_adjustments were obviously distorted in Chinese locale:

> 一段非常短的中文标题

Will be flag to "far too long". So I change the adjustments from 70/160 to 110/160, now it's fit the actual situation.