### PR TITLE
Fix PHP 8+ undefined array key warning in merge_extra_image_details

### DIFF
--- a/inc/classes/meta/image.class.php
+++ b/inc/classes/meta/image.class.php
@@ -689,7 +689,7 @@ class Image {
 	 */
 	public static function merge_extra_image_details( $details, $size = 'full' ) {
 
-		if ( $details['id'] ) {
+		if ( ! empty( $details['id'] ) ) {
 			// This returns an array with 'width' and 'height' indexes.
 			$details += Image\Utils::get_image_dimensions( $details['id'], $size );
 			// TODO PHP 8.1+ String unpacking in array, so we can directly add the above to it:


### PR DESCRIPTION
## Problem

Accessing `$details['id']` directly on line 692 triggers a PHP 8+ warning when the array key doesn't exist:

```
PHP Warning: Undefined array key "id" in inc/classes/meta/image.class.php on line 692
```

## Solution

Replace `if ( $details['id'] )` with `if ( ! empty( $details['id'] ) )` to safely check the key existence before accessing it.

This PR adds the fix.