### PR TITLE
Remove XHTML self-closing syntax from void meta tags

### DIFF
--- a/inc/classes/front/meta/tags.class.php
+++ b/inc/classes/front/meta/tags.class.php
@@ -135,12 +135,10 @@ final class Tags {
 	}
 
 	/**
-	 * Renders an XHTML element. Sane drop-in for DOMDocument and whatnot.
-	 *
-	 * Even though most (if not all) WordPress sites use HTML5, we expect some still use XHTML.
-	 * We expect HTML5 fully on the back-end.
+	 * Renders an HTML5 element. Sane, performant, and secure drop-in for DOMDocument and whatnot.
 	 *
 	 * @since 5.0.0
+	 * @since 5.1.5 Removed XHTML support. The tags are now always rendered in HTML5 syntax.
 	 *
 	 * @param array         $attributes {
 	 *                          Associative array of tag names and tag values.
@@ -216,8 +214,9 @@ final class Tags {
 			);
 		}
 
-		// phpcs:disable WordPress.Security.EscapeOutput -- already escaped.
+		// phpcs:disable WordPress.Security.EscapeOutput -- $attr is escaped above, and $content is conditionally escaped below.
 		if ( isset( $content ) ) {
+			// Normal elements.
 			vprintf(
 				'<%1$s%2$s>%3$s</%1$s>',
 				[
@@ -234,6 +233,7 @@ final class Tags {
 				],
 			);
 		} else {
+			// Void elements.
 			printf(
 				'<%s%s>',
 				/** @link <https://www.w3.org/TR/2011/WD-html5-20110525/syntax.html#syntax-tag-name> */

--- a/inc/classes/front/meta/tags.class.php
+++ b/inc/classes/front/meta/tags.class.php
@@ -235,7 +235,7 @@ final class Tags {
 			);
 		} else {
 			printf(
-				'<%s%s />', // XHTML compatible.
+				'<%s%s>',
 				/** @link <https://www.w3.org/TR/2011/WD-html5-20110525/syntax.html#syntax-tag-name> */
 				preg_replace( '/[^0-9a-zA-Z]+/', '', $tag ),
 				$attr,

--- a/readme.txt
+++ b/readme.txt
@@ -267,6 +267,8 @@ You can also output these breadcrumbs visually in your theme by [using a shortco
 		* Updated radio buttons and checkboxes to accomodate for WordPress 7.0.
 	* **Robots.txt:**
 		* Sitemap Hinting now correctly outputs WordPress Core sitemap URLs when "Optimized Sitemap" output is disabled.
+	* **Head tags:**
+		* The metatag generator now always outputs in HTML5 syntax, dropping XHTML support.
 **Notes:**
 	* WordPress 6.7 is now required, from 6.0. This allowed us to drop some legacy workarounds.
 		* Since WordPress doesn't adhere to Semantic Versioning (SemVer), this is actually a minor bump -- so we didn't bother highlighting it.


### PR DESCRIPTION
HTML5 was finalized as a W3C Recommendation in October 2014 and has been the de-facto standard for much longer.

On void elements (`<meta>`, `<link>`, `<img>`, etc.), the trailing `/` is permitted but has no meaning and the HTML spec explicitly ignores it.

It's a leftover from XHTML that adds bytes to every page for zero benefit.

This PR drops the trailing space and slash from the `<meta>` and `<link>` tags emitted by the plugin, so the output matches modern HTML5 conventions.

<details>
    <summary>Example of the difference</summary>

## Before

```
<meta name="robots" content="max-snippet:-1,max-image-preview:standard,max-video-preview:-1" />
<meta name="description" content="Roots helps you build better WordPress sites faster. Open&#x2d;source tools that cover the full WordPress stack for the professional developer." />
<meta property="og:image" content="https://roots.io/app/uploads/social/2.png" />
<meta property="og:locale" content="en_US" />
<meta property="og:type" content="website" />
<meta property="og:title" content="Roots | Modern WordPress Development" />
<meta property="og:description" content="Roots helps you build better WordPress sites faster. Open&#x2d;source tools that cover the full WordPress stack for the professional developer." />
<meta property="og:url" content="https://roots.io/" />
<meta property="og:site_name" content="Roots" />
<meta name="twitter:card" content="summary_large_image" />
<meta name="twitter:title" content="Roots | Modern WordPress Development" />
<meta name="twitter:description" content="Roots helps you build better WordPress sites faster. Open&#x2d;source tools that cover the full WordPress stack for the professional developer." />
<meta name="twitter:image" content="https://roots.io/app/uploads/social/2.png" />
<link rel="canonical" href="https://roots.io/" />
```

## After

```
<meta name="robots" content="max-snippet:-1,max-image-preview:standard,max-video-preview:-1">
<link rel="canonical" href="https://roots.io/">
<meta name="description" content="Roots helps you build better WordPress sites faster. Open-source tools that cover the full WordPress stack for the professional developer.">
<meta property="og:type" content="website">
<meta property="og:locale" content="en_US">
<meta property="og:site_name" content="Roots">
<meta property="og:title" content="Roots | Modern WordPress Development">
<meta property="og:description" content="Roots helps you build better WordPress sites faster. Open-source tools that cover the full WordPress stack for the professional developer.">
<meta property="og:url" content="https://roots.io/">
<meta property="og:image" content="https://roots.io/app/uploads/social/2.png">
<meta name="twitter:card" content="summary_large_image">
<meta name="twitter:title" content="Roots | Modern WordPress Development">
<meta name="twitter:description" content="Roots helps you build better WordPress sites faster. Open-source tools that cover the full WordPress stack for the professional developer.">
<meta name="twitter:image" content="https://roots.io/app/uploads/social/2.png">
```

</details>

