### PR TITLE
Add option to filter available webmaster tools settings fields

### DIFF
--- a/inc/classes/admin/settings/plugin.class.php
+++ b/inc/classes/admin/settings/plugin.class.php
@@ -10,6 +10,7 @@ namespace The_SEO_Framework\Admin\Settings;
 
 use The_SEO_Framework\{
 	Admin,
+	Front\Meta\Generator\Webmasters,
 	Helper\Post_Type,
 	Helper\Template,
 };
@@ -176,7 +177,7 @@ final class Plugin {
 			);
 
 		// Webmaster Meta Box
-		if ( $webmaster )
+		if ( $webmaster && !empty(Webmasters::get_enabled_generators()) )
 			\add_meta_box(
 				'autodescription-webmaster-settings',
 				\esc_html__( 'Webmaster Meta Settings', 'autodescription' ),

--- a/inc/classes/front/meta/generator/webmasters.class.php
+++ b/inc/classes/front/meta/generator/webmasters.class.php
@@ -47,11 +47,29 @@ final class Webmasters {
 		[ __CLASS__, 'generate_pinterest_verification' ],
 	];
 
+	public static function get_enabled_generators(): array {
+		$generator_functions = array_column(self::GENERATORS, 1);
+		$mapped = array_reduce($generator_functions, function($carry, $func) {
+			$key = str_replace('generate_', '', $func);
+			$key = str_replace('_verification', '', $key);
+			$carry[$key] = $func;
+
+			return $carry;
+		}, []);
+
+		return apply_filters('the_seo_framework_webmaster_fields', $mapped);
+	}
+
+	public static function is_generator_enabled($generator_key): bool {
+		return in_array($generator_key, array_keys(self::get_enabled_generators()));
+	}
+
 	/**
 	 * @since 5.0.0
 	 * @generator
 	 */
 	public static function generate_google_verification() {
+		if(!self::is_generator_enabled('google')) return;
 
 		$code = Data\Plugin::get_option( 'google_verification' );
 
@@ -69,6 +87,7 @@ final class Webmasters {
 	 * @generator
 	 */
 	public static function generate_bing_verification() {
+		if(!self::is_generator_enabled('bing')) return;
 
 		$code = Data\Plugin::get_option( 'bing_verification' );
 
@@ -86,6 +105,7 @@ final class Webmasters {
 	 * @generator
 	 */
 	public static function generate_yandex_verification() {
+		if(!self::is_generator_enabled('yandex')) return;
 
 		$code = Data\Plugin::get_option( 'yandex_verification' );
 
@@ -103,6 +123,7 @@ final class Webmasters {
 	 * @generator
 	 */
 	public static function generate_baidu_verification() {
+		if(!self::is_generator_enabled('baidu')) return;
 
 		$code = Data\Plugin::get_option( 'baidu_verification' );
 
@@ -120,6 +141,7 @@ final class Webmasters {
 	 * @generator
 	 */
 	public static function generate_pinterest_verification() {
+		if(!self::is_generator_enabled('pinterest')) return;
 
 		$code = Data\Plugin::get_option( 'pint_verification' );
 

--- a/inc/views/settings/metaboxes/webmaster.php
+++ b/inc/views/settings/metaboxes/webmaster.php
@@ -12,6 +12,7 @@ use The_SEO_Framework\Admin\Settings\Layout\{
 	HTML,
 	Input,
 };
+use The_SEO_Framework\Front\Meta\Generator\Webmasters;
 
 // phpcs:disable WordPress.WP.GlobalVariablesOverride -- This isn't the global scope.
 
@@ -93,6 +94,10 @@ switch ( $instance ) : // Quite useless, but prepared for expansion.
 			],
 		];
 
+		$enabled_settings = array_filter($settings, function($setting) {
+			return Webmasters::is_generator_enabled($setting);
+		}, ARRAY_FILTER_USE_KEY);
+
 		HTML::header_title( \__( 'Webmaster Integration Settings', 'autodescription' ) );
 		HTML::description( \__( "When adding your website to Google, Bing and other Webmaster Tools, you'll be asked to add a code or file to your website for verification purposes. These options will help you easily integrate those codes.", 'autodescription' ) );
 		HTML::description( \__( "Verifying your website has no SEO value whatsoever. But you might gain added benefits such as search ranking insights to help you improve your website's content.", 'autodescription' ) );
@@ -100,7 +105,7 @@ switch ( $instance ) : // Quite useless, but prepared for expansion.
 		?>
 		<hr>
 		<?php
-		foreach ( $settings as $setting ) {
+		foreach ( $enabled_settings as $setting ) {
 			printf(
 				'<p><label for=%s><strong>%s</strong> %s</label></p>',
 				\esc_attr( Input::get_field_id( $setting['setting'] ) ),


### PR DESCRIPTION
## Change summary
This PR adds a filter to customise which webmaster tools fields are available in the settings. 

Example usage:
```php
add_filter('the_seo_framework_webmaster_fields', function($fields) {
	unset($fields['pinterest']);
	unset($fields['yandex']);
	unset($fields['baidu']);

	if(is_plugin_active('google-site-kit/google-site-kit.php')) {
		unset($fields['google']);
	}

	return $fields;
});
```
In this example, the metabox would be shown with the Bing field only if Google Site Kit is enabled (as that takes care of the Google Search Console connection), or Bing and Google if it is not. 

If Bing was also disabled, the metabox would not be shown at all if Google Site Kit is enabled.

## Implementation notes

This works similarly to the post type archive metabox, in that it also provides a method to check if at least one is enabled before outputting the meta box at all. 

The key-value mapping used in `get_enabled_generators()` to create an associative array rather than a simple indexed one as `$generator_functions = array_column(self::GENERATORS, 1);` provides is purely to enable simple usage of the filter. This way, the developer can use `unset` rather than needing to use `array_filter`, `array_find`, `array_search`, or similar to locate and remove fields.

### Other options considered
It would be much simpler to filter `$settings` directly in `inc/views/settings/metaboxes/webmaster.php` - a single line `apply_filters(...)` there would prevent the disabled fields from showing. However, that would mean the metabox is still shown - albeit with no fields - if all are disabled and the developer has not used the `the_seo_framework_webmaster_metabox` filter to disable it. This would not be as intuitive as having the plugin automatically handle it.
